### PR TITLE
Chemist in C#

### DIFF
--- a/24 Chemist/csharp/Chemist/Chemist.sln
+++ b/24 Chemist/csharp/Chemist/Chemist.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31005.135
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Chemist", "Chemist\Chemist.csproj", "{8CC70F80-F2D6-47B6-8976-079352AC6C85}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8CC70F80-F2D6-47B6-8976-079352AC6C85}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8CC70F80-F2D6-47B6-8976-079352AC6C85}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8CC70F80-F2D6-47B6-8976-079352AC6C85}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8CC70F80-F2D6-47B6-8976-079352AC6C85}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {4AFDA581-82B1-42C7-9C9C-26F6B4288584}
+	EndGlobalSection
+EndGlobal

--- a/24 Chemist/csharp/Chemist/Chemist/Chemist.csproj
+++ b/24 Chemist/csharp/Chemist/Chemist/Chemist.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/24 Chemist/csharp/Chemist/Chemist/Program.cs
+++ b/24 Chemist/csharp/Chemist/Chemist/Program.cs
@@ -1,0 +1,49 @@
+﻿using System;
+const int maxLives = 9;
+
+WriteCentred("Chemist");
+WriteCentred("Creative Computing, Morristown, New Jersey");
+Console.WriteLine(@"
+
+
+The fictitious chemical kryptocyanic acid can only be
+diluted by the ratio of 7 parts water to 3 parts acid.
+If any other ratio is attempted, the acid becomes unstable
+and soon explodes.  Given the amount of acid, you must
+decide who much water to add for dilution.  If you miss
+you face the consequences.
+");
+
+var random = new Random();
+int livesUsed = 0;
+while (livesUsed < maxLives)
+{
+    int krypto = random.Next(1, 50);
+    double water = krypto * 7.0 / 3.0;
+
+    Console.WriteLine($"{krypto} Liters of kryptocyanic acid.  How much water?");
+    double answer = double.Parse(Console.ReadLine());
+
+    double diff = Math.Abs(answer - water);
+    if (diff <= water / 20)
+    {
+        Console.WriteLine("Good job! You may breathe now, but don't inhale the fumes"!);
+        Console.WriteLine();
+    }
+    else
+    {
+        Console.WriteLine("Sizzle!  You have just been desalinated into a blob\nof quivering protoplasm!");
+        Console.WriteLine();
+        livesUsed++;
+
+        if (livesUsed < maxLives)
+            Console.WriteLine("However, you may try again with another life.");
+    }
+}
+Console.WriteLine($"Your {maxLives} lives are used, but you will be long remembered for\nyour contributions to the field of comic book chemistry.");
+
+static void WriteCentred(string text)
+{
+    int indent = (Console.WindowWidth + text.Length) / 2;
+    Console.WriteLine($"{{0,{indent}}}", text);
+}


### PR DESCRIPTION
Chemist translated to C#.

Uses C#9, targeting .Net 5.0.
Uses top-level statements to avoid need for namespace, class and `static void Main`.