### PR TITLE
docs: Missing raku language

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Each project has subfolders corresponding to the languages we'd like to see the 
 - Java
 - JavaScript
 - Python
+- Raku
 - Ruby
 - VB.NET
 


### PR DESCRIPTION
On top level README.md there is no mention to the raku language that figures on the source folders