### PR TITLE
Fix duplicate card bug

### DIFF
--- a/01_Acey_Ducey/ruby/aceyducey.rb
+++ b/01_Acey_Ducey/ruby/aceyducey.rb
@@ -56,9 +56,9 @@ while true # Game loop
   puts
   puts "HERE ARE YOUR NEXT TWO CARDS:"
 
-  # Randomly draw two cards from 2 to 14 and make sure the first card is lower in value than the second
+  # Randomly draw two cards and make sure the first card is lower in value than the second
   # Using array destructuring, this sorted array can be assigned to `first_card` and `second_card`
-  first_card, second_card = [rand(2..14), rand(2..14)].sort
+  first_card, second_card = (2...14).to_a.shuffle.pop(2).sort
 
   # Helper method to convert a numeric card into a String for printing
   def card_name(card)


### PR DESCRIPTION
<img width="251" alt="Screen Shot 2022-01-03 at 2 41 56 am" src="https://user-images.githubusercontent.com/208544/147881507-c2f1a880-0ce8-48f3-876e-6a94cce12b0b.png">

The current implementation can have the two cards with the same number contrary to the BASIC implementation.

<img width="235" alt="Screen Shot 2022-01-03 at 3 14 53 am" src="https://user-images.githubusercontent.com/208544/147881950-a15bc4cb-5d26-4dff-8aa2-0594954bbfa5.png">


C# implementation has the same problem - https://github.com/coding-horror/basic-computer-games/blob/main/01_Acey_Ducey/csharp/Game.cs#L82