### PR TITLE
Update game readme

### DIFF
--- a/01_Acey_Ducey/README.md
+++ b/01_Acey_Ducey/README.md
@@ -1,7 +1,16 @@
 ### Acey Ducey
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=2
+This is a simulation of the Acey Ducey card game. In the game, the dealer (the computer) deals two cards face up. You have an option to bet or not to bet depending on whether or not you feel the next card dealt will have a value between the first two.
+
+Your initial money is set to $100; you may want to alter this value if you want to start with more or less than $100. The game keeps going on until you lose all your money or interrupt the program.
+
+The original program author was Bill Palmby of Prairie View, Illinois.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=2)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=17)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/02_Amazing/README.md
+++ b/02_Amazing/README.md
@@ -1,7 +1,14 @@
 ### Amazing
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=3
+This program will print out a different maze every time it is run and guarantees only one path through. You can choose the dimensions of the maze — i.e. the number of squares wide and long.
+
+The original program author was Jack Hauber of Windsor, Connecticut.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=3)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=18)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/03_Animal/README.md
+++ b/03_Animal/README.md
@@ -1,7 +1,22 @@
 ### Animal
 
+Unlike other computer games in which the computer picks a number or letter and you must guess what it is, in this game _you_ think of an animal and the _computer_ asks you questions and tries to guess the name of your animal. If the computer guesses incorrectly, it will ask you for a question that differentiates the animal you were thinking of. In this way the computer “learns” new animals. Questions to differentiate new animals should be input without a question mark.
+
+This version of the game does not have a SAVE feature. If your system allows, you may modify the program to save and reload the array when you want to play the game again. This way you can save what the computer learns over a series of games.
+
+At any time if you reply “LIST” to the question “ARE YOU THINKING OF AN ANIMAL,” the computer will tell you all the animals it knows so far.
+
+The program starts originally by knowing only FISH and BIRD. As you build up a file of animals you should use broad, general questions first and then narrow down to more specific ones with later animals. For example, if an elephant was to be your first animal, the computer would ask for a question to distinguish an elephant from a bird. Naturally, there are hundreds of possibilities, however, if you plan to build a large file of animals a good question would be “IS IT A MAMMAL.”
+
+This program can be easily modified to deal with categories of things other than animals by simply modifying the initial data and the dialogue references to animals. In an educational environment, this would be a valuable program to teach the distinguishing characteristics of many classes of objects — rock formations, geography, marine life, cell structures, etc.
+
+Originally developed by Arthur Luehrmann at Dartmouth College, Animal was subsequently shortened and modified by Nathan Teichholtz at DEC and Steve North at Creative Computing.
+
+---
+
 As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=4
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=4)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=19)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/04_Awari/README.md
+++ b/04_Awari/README.md
@@ -1,7 +1,38 @@
 ### Awari
 
+Awari is an ancient African game played with seven sticks and thirty-six stones or beans laid out as shown above. The board is divided into six compartments or pits on each side. In addition, there are two special home pits at the ends.
+
+A move is made by taking all the beans from any (non-empty) pit on your own side. Starting from the pit to the right of this one, these beans are ‘sown’ one in each pit working around the board anticlockwise.
+
+A turn consists of one or two moves. If the last bean of your move is sown in your own home you may take a second move.
+
+If the last bean sown in a move lands in an empty pit, provided that the opposite pit is not empty, all the beans in the opposite pit, together with the last bean sown are ‘captured’ and moved to the player’s home.
+
+When either side is empty, the game is finished. The player with the most beans in his home has won.
+
+In the computer version, the board is printed as 14 numbers representing the 14 pits.
+
+```
+    3   3   3   3   3   3
+0                           0
+    3   3   3   3   3   3
+```
+
+The pits on your (lower) side are numbered 1-6 from left to right. The pits on my (the computer’s) side are numbered from my left (your right).
+
+To make a move you type in the number of a pit. If the last bean lands in your home, the computer types ‘AGAIN?’ and then you type in your second move.
+
+The computer’s move is typed, followed by a diagram of the board in its new state. The computer always offers you the first move. This is considered to be a slight advantage.
+
+There is a learning mechanism in the program that causes the play of the computer to improve as it playes more games.
+
+The original version of Awari is adopted from one originally written by Geoff Wyvill of Bradford, Yorkshire, England.
+
+---
+
 As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=6
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=6)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=21)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/05_Bagels/README.md
+++ b/05_Bagels/README.md
@@ -1,7 +1,20 @@
 ### Bagels
 
+In this game, the computer picks a 3-digit secret number using the digits 0 to 9 and you attempt to guess what it is. You are allowed up to twenty guesses. No digit is repeated. After each guess the computer will give you clues about your guess as follows:
+
+- PICO    One digit is correct, but in the wrong place
+- FERMI    One digit is in the correct place
+- BAGELS   No digit is correct
+
+You will learn to draw inferences from the clues and, with practice, you’ll learn to improve your score. There are several good strategies for playing Bagels. After you have found a good strategy, see if you can improve it. Or try a different strategy altogether to see if it is any better. While the program allows up to twenty guesses, if you use a good strategy it should not take more than eight guesses to get any number.
+
+The original authors of this program are D. Resek and P. Rowe of the Lawrence Hall of Science, Berkeley, California.
+
+---
+
 As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=9
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=9)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=21)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/06_Banner/README.md
+++ b/06_Banner/README.md
@@ -1,7 +1,14 @@
 ### Banner
 
+This program creates a large banner on a terminal of any message you input. The letters may be any dimension of you wish although the letter height plus distance from left-hand side should not exceed 6 inches. Experiment with the height and width until you get a pleasing effect on whatever terminal you are using.
+
+This program was written by Leonard Rosendust of Brooklyn, New York.
+
+---
+
 As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=10
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=10)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=25)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/07_Basketball/README.md
+++ b/07_Basketball/README.md
@@ -1,7 +1,30 @@
 ### Basketball
 
+This program simulates a game of basketball between Dartmouth College and an opponent of your choice. You are the Dartmouth captain and control the type of shot and defense during the course of the game.
+
+There are four types of shots:
+1. Long Jump Shot (30ft)
+2. Short Jump Shot (15ft)
+3. Lay Up
+4. Set Shot
+
+Both teams use the same defense, but you may call it:
+- Enter (6): Press
+- Enter (6.5): Man-to-man
+- Enter (7): Zone
+- Enter (7.5): None
+
+To change defense, type “0” as your next shot.
+
+Note: The game is biased slightly in favor of Dartmouth. The average probability of a Dartmouth shot being good is 62.95% compared to a probability of 61.85% for their opponent. (This makes the sample run slightly remarkable in that Cornell won by a score of 45 to 42 Hooray for the Big Red!)
+
+Charles Bacheller of Dartmouth College was the original author of this game.
+
+---
+
 As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=12
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=12)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=27)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/08_Batnum/README.md
+++ b/08_Batnum/README.md
@@ -1,7 +1,20 @@
 ### Batnum
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=14
+The game starts with an imaginary pile of objects, coins for example. You and your opponent (the computer) alternately remove objects from the pile. You specify in advance the minimum and maximum number of objects that can be taken on each turn. You also specify in advance how winning is defined:
+1. To take the last object
+2. To avoid taking the last object
+
+You may also determine whether you or the computer go first.
+
+The strategy of this game is based on modulo arithmetic. If the maximum number of objects a player may remove in a turn is M, then to gain a winning position a player at the end of his turn must leave a stack of 1 modulo (M+1) coins. If you don’t understand this, play the game 23 Matches first, then BATNUM, and have fun!
+
+BATNUM is a generalized version of a great number of manual remove-the-object games. The original computer version was written by one of the two originators of the BASIC language, John Kemeny of Dartmouth College.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=14)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=29)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/09_Battle/README.md
+++ b/09_Battle/README.md
@@ -1,7 +1,27 @@
 ### Battle
 
+BATTLE is based on the popular game Battleship which is primarily played to familiarize people with the location and designation of points on a coordinate plane.
+
+BATTLE first randomly sets up the bad guy’s fleet disposition on a 6 by 6 matrix or grid. The fleet consists of six ships:
+- Two destroyers (ships number 1 and 2) which are two units long
+- Two cruisers (ships number 3 and 4) which are three units long
+- Two aircraft carriers (ships number 5 and 6) which are four units long
+
+The program then prints out this fleet disposition in a coded or disguised format (see the sample computer print-out). You then proceed to sink the various ships by typing in the coordinates (two digits. each from 1 to 6, separated by a comma) of the place where you want to drop a bomb, if you’ll excuse the expression. The computer gives the appropriate response (splash, hit, etc.) which you should record on a 6 by 6 matrix. You are thus building a representation of the actual fleet disposition which you will hopefully use to decode the coded fleet disposition printed out by the computer. Each time a ship is sunk, the computer prints out which ships have been sunk so far and also gives you a “SPLASH/HIT RATIO.”
+
+The first thing you should learn is how to locate and designate positions on the matrix, and specifically the difference between “3,4” and “4,3.” Our method corresponds to the location of points on the coordinate plane rather than the location of numbers in a standard algebraic matrix: the first number gives the column counting from left to right and the second number gives the row counting from bottom to top.
+
+The second thing you should learn about is the splash/hit ratio. “What is a ratio?” A good reply is “It’s a fraction or quotient.” Specifically, the spash/hit ratio is the number of splashes divided by the number of hits. If you had 9 splashes and 15 hits, the ratio would be 9/15 or 3/5, both of which are correct. The computer would give this splash/hit ratio as .6.
+
+The main objective and primary education benefit of BATTLE comes from attempting to decode the bas guys’ fleet disposition code. To do this, you must make a comparison between the coded matrix and the actual matrix which you construct as you play the game.
+
+The original author of both the program and these descriptive notes is Ray Westergard of Lawrence Hall of Science, Berkeley, California.
+
+---
+
 As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=15
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=15)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=30)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/10_Blackjack/README.md
+++ b/10_Blackjack/README.md
@@ -1,7 +1,16 @@
 ### Blackjack
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=18
+This is a simulation of the card game of Blackjack or 21, Las Vegas style. This rather comprehensive version allows for up to seven players. On each hand a player may get another card (a hit), stand, split a hand in the event two identical cards were received or double down. Also, the dealer will ask for an insurance bet if he has an exposed ace.
+
+Cards are automatically reshuffled as the 51st card is reached. For greater realism, you may wish to change this to the 41st card. Actually, fanatical purists will want to modify the program so it uses three decks of cards instead of just one.
+
+This program originally surfaced at Digital Equipment Corp.; the author is unknown.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=18)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=33)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/11_Bombardment/README.md
+++ b/11_Bombardment/README.md
@@ -1,7 +1,16 @@
 ### Bombardment
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=22
+BOMBARDMENT is played on two, 5x5 grids or boards with 25 outpost locations numbered 1 to 25. Both you and the computer have four platoons of troops that can be located at any four outposts on your respective grids.
+
+At the start of the game, you locate (or hide) your four platoons on your grid. The computer does the same on it’s grid. You then take turns firing missiles or bombs at each other’s outposts trying to destroy all four platoons. The one who finds all four opponents’ platoons first, wins.
+
+This program was slightly modified from the original written by Martin Burdash of Parlin, New Jersey.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=22)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=37)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/12_Bombs_Away/README.md
+++ b/12_Bombs_Away/README.md
@@ -1,7 +1,14 @@
 ### Bombs Away
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=24
+In this program, you fly a World War II bomber for one of the four protagonists of the war. You then pick your target or the type of plane you are flying. Depending on your flying experience and the quality of enemy defenders, you then may accomplish your mission, get shot down, or make it back through enemy fire. In any case, you get a change to fly again.
+
+David Ahl modified the original program which was created by David Sherman while a student at Curtis Jr. High School, Sudbury, Massachusetts.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=24)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=39)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/13_Bounce/README.md
+++ b/13_Bounce/README.md
@@ -1,7 +1,16 @@
 ### Bounce
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=25
+This program plots a bouncing ball. Most computer plots run along the paper in the terminal (top to bottom); however, this plot is drawn horizontally on the paper (left to right).
+
+You may specify the initial velocity of the ball and the coefficient of elasticity of the ball (a superball is about 0.85 — other balls are much less). You also specify the time increment to be used in “strobing” the flight of the ball. In other words, it is as though the ball is thrown up in a darkened room and you flash a light at fixed time intervals and photograph the progress of the ball.
+
+The program was originally written by Val Skalabrin while he was at DEC.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=25)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=40)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/14_Bowling/README.md
+++ b/14_Bowling/README.md
@@ -1,7 +1,18 @@
 ### Bowling
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=26
+This is a simulated bowling game for up to four players. You play 10 frames. To roll the ball, you simply type “ROLL.” After each roll, the computer will show you a diagram of the remaining pins (“0” means the pin is down, “+” means it is still standing), and it will give you a roll analysis:
+- GUTTER
+- STRIKE
+- SPARE
+- ERROR (on second ball if pins still standing)
+
+Bowling was written by Paul Peraino while a student at Woodrow Wilson High School, San Francisco, California.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=26)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=41)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/15_Boxing/README.md
+++ b/15_Boxing/README.md
@@ -1,7 +1,16 @@
 ### Boxing
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=28
+This program simulates a three-round Olympic boxing match. The computer coaches one of the boxers and determines his punches and defences, while you do the same for your boxer. At the start of the match, you may specify your man’s best punch and his vulnerability.
+
+There are approximately seven major punches per round, although this may be varied. The best out if three rounds wins.
+
+Jesse Lynch of St. Paul, Minnesota created this program.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=28)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=43)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/16_Bug/README.md
+++ b/16_Bug/README.md
@@ -1,7 +1,18 @@
 ### Bug
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=30
+The object of this game is to finish your drawing of a bug before the computer finishes.
+
+You and the computer roll a die alternately with each number standing for a part of the bug. You must add the parts in the right order; in other words, you cannot have a neck until you have a body, you cannot have a head until you have a neck, and so on. After each new part has been added, you have the option of seeing pictures of the two bugs.
+
+If you elect to see all the pictures, this program has the ability of consuming well over six feet of terminal paper per run. We can only suggest recycling the paper by using the other side.
+
+Brian Leibowitz wrote this program while in the 7th grade at Harrison Jr-Se High School in Harrison, New York.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=30)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=45)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/17_Bullfight/README.md
+++ b/17_Bullfight/README.md
@@ -1,7 +1,25 @@
 ### Bullfight
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=32
+In this simulated bullfight, you are the matador — i.e., the one with the principle role and the one who must kill the bull or be killed (or run from the ring).
+
+On each pass of the bull, you may try:
+- 0: Veronica (dangerous inside move of the cape)
+- 1: Less dangerous outside move of the cape
+- 2: Ordinary swirl of the cape
+
+Or you may try to kill the bull:
+- 4: Over the horns
+- 5: In the chest
+
+The crowd will determine what award you deserve, posthumously if necessary. The braver you are, the better the reward you receive. It’s nice to stay alive too. The better the job the picadores and toreadores do, the better your chances.
+
+David Sweet of Dartmouth wrote the original version of this program. It was then modified by students at Lexington High School and finally by Steve North of Creative Computing.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=32)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=47)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/18_Bullseye/README.md
+++ b/18_Bullseye/README.md
@@ -1,7 +1,36 @@
 ### Bullseye
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=34
+In this game, up to 20 players throw darts at a target with 10-, 20-, 30-, and 40-point zones. The objective is to get 200 points.
+
+You have a choice of three methods of throwing:
+
+| Throw | Description        | Probable Score            |
+|-------|--------------------|---------------------------|
+| 1     | Fast overarm       | Bullseye or complete miss |
+| 2     | Controlled overarm | 10, 20, or 30 points      |
+| 3     | Underarm           | Anything                  |
+
+You will find after playing a while that different players will swear by different strategies. However, considering the expected score per throw by always using throw 3:
+
+| Score (S) | Probability (P) | S x P |
+|-----------|-----------------|-------|
+|     40    |  1.00-.95 = .05 |   2   |
+|     30    |  .95-.75 = .20  |   6   |
+|     30    |  .75-.45 = .30  |   6   |
+|     10    |  .45-.05 = .40  |   4   |
+|     0     |  .05-.00 = .05  |   0   |
+
+Expected score per throw = 18
+
+Calculate the expected score for the other throws and you may be surprised!
+
+The program was written by David Ahl of Creative Computing.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=34)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=49)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/19_Bunny/README.md
+++ b/19_Bunny/README.md
@@ -1,7 +1,8 @@
 ### Bunny
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=35
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=35)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=50)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/20_Buzzword/README.md
+++ b/20_Buzzword/README.md
@@ -1,7 +1,14 @@
 ### Buzzword
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=36
+This program is an invaluable aid for preparing speeches and briefings about educational technology. This buzzword generator provides sets of three highly-acceptable words to work into your material. Your audience will never know that the phrases don’t really mean much of anything because they sound so great! Full instructions for running are given in the program.
+
+This version of Buzzword was written by David Ahl.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=36)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=51)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/21_Calendar/README.md
+++ b/21_Calendar/README.md
@@ -1,7 +1,23 @@
 ### Calendar
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=37
+This program prints out a calendar for any year. You must specify the starting day of the week of the year:
+- 0: Sunday
+- -1: Monday
+- -2: Tuesday
+- -3: Wednesday
+- -4: Thursday
+- -5: Friday
+- -6: Saturday
+
+You can determine this by using the program WEEKDAY. You must also make two changes for leap years. The program listing describes the necessary changes. Running the program produces a nice 12-month calendar.
+
+The program was written by Geoffrey Chase of the Abbey, Portsmouth, Rhode Island.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=37)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=52)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/22_Change/README.md
+++ b/22_Change/README.md
@@ -1,7 +1,12 @@
 ### Change
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=39
+In this program, the computer pretends it is the cashier at your friendly neighborhood candy store. You tell it the cost of the item(s) you are buying, the amount of your payment, and it will automatically (!) determine your correct change. Aren’t machines wonderful? Dennis Lunder of People’s Computer Company wrote this program.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=39)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=54)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/23_Checkers/README.md
+++ b/23_Checkers/README.md
@@ -1,7 +1,16 @@
 ### Checkers
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=40
+This program plays checkers. The pieces played by the computer are marked with an “X”, yours are marked “O”. A move is made by specifying the coordinates of the piece to be moved (X, Y). Home (0,0) is in the bottom left and X specifies distance to the right of home (i.e., column) and Y specifies distance above home (i.e. row). You then specify where you wish to move to.
+
+THe original version of the program by Alan Segal was not able to recognize (or permit) a double or triple jump. If you tried one, it was likely that your piece would disappear altogether!
+
+Steve North of Creative Computing rectified this problem and Lawrence Neal contributed modifications to allow the program to tell which player has won the game. The computer does not play a particularly good game but we leave it to _you_ to improve that.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=40)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=55)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/24_Chemist/README.md
+++ b/24_Chemist/README.md
@@ -1,7 +1,14 @@
 ### Chemist
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=42
+The fictitious chemical, kryptocyanic acid, can only be diluted by the ratio of 7 parts water to 3 parts acid. Any other ratio causes an unstable compound which soon explodes. Given an amount of acid, you must determine how much water to add to the dilution. If you’re more than 5% off, you lose one of your nine lives. The program continues to play until you lose all nine lives or until it is interrupted.
+
+It was originally written by Wayne Teeter of Ridgecrest, California.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=42)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=57)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/25_Chief/README.md
+++ b/25_Chief/README.md
@@ -1,7 +1,16 @@
 ### Chief
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=43
+In the words of the program author, John Graham, “CHIEF is designed to give people (mostly kids) practice in the four operations (addition, multiplication, subtraction, and division).
+
+It does this while giving people some fun. And then, if the people are wrong, it shows them how they should have done it.
+
+CHIEF was written by John Graham of Upper Brookville, New York.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=43)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=58)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/26_Chomp/README.md
+++ b/26_Chomp/README.md
@@ -1,7 +1,16 @@
 ### Chomp
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=44
+This program is an adaptation of a mathematical game originally described by Martin Gardner in the January 1973 issue of _Scientific American_. Up to a 9x9 grid is set up by you with the upper left square in a poison square. This grid is the cookie. Players alternately chomp away at the cookie from the lower right. To take a chomp, input a row and column number of one of the squares remaining on the cookie. All of the squares below and to the right of that square, including that square, disappear.
+
+Any number of people can play — the computer is only the moderator; it is not a player. Two-person strategies are interesting to work out but strategies when three or more people are playing are the real challenge.
+
+The computer version of the game was written by Peter Sessions of People’s Computer Company.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=44)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=59)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/27_Civil_War/README.md
+++ b/27_Civil_War/README.md
@@ -1,7 +1,18 @@
 ### Civil War
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=46
+This simulation is based on 14 battles in the Civil War. Facts and figures are based on the actual occurrence. If you follow the same strategy used in the actual battle, the results will be the same. Generally, this is a good strategy since the generals in the Civil War were fairly good military strategists. However, you can frequently outperform the Civil War generals, particularly in cases where they did not have good enemy intelligence and consequently followed a poor course of action. Naturally, it helps to know your Civil War history, although the computer gives yuo the rudiments.
+
+After each of the 14 battles, your casualties are compared to the actual casualties of the battle, and you are told whether you win or lose the battle.
+
+You may play Civil War alone in which case the program simulates the Union general. Or two players may play in which case the computer becomes the moderator.
+
+Civil War was written in 1968 by three Students in Lexington High School, Massachusetts: L. Cram, L. Goodie, and D. Hibbard. It was modified into a 2-player game by G. Paul and R. Hess of TIES, St. Paul, Minnesota.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=46)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=61)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/28_Combat/README.md
+++ b/28_Combat/README.md
@@ -1,7 +1,16 @@
 ### Combat
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=50
+In this game, you are fighting a small-scale war with the computer. You have 72,000 troops which you first ust distribute among your Army, Navy, and Air Force. You may distribute them in any way you choose as long as you don’t use more than 72,000.
+
+You then attack your opponent (the computer) and input which service and the number of men you wish to use. The computer then tells you the outcome of the battle, gives you the current statistics and allows you to determine your next move.
+
+After the second battle, it is decided from the total statistics whether you win or lose or if a treaty is signed.
+
+This program was created by Bob Dores of Milton, Massachusetts.
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=50)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=65)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/29_Craps/README.md
+++ b/29_Craps/README.md
@@ -1,7 +1,19 @@
 ### Craps
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=52
+This game simulates the game of craps played according to standard Nevada craps table rules. That is:
+1. A 7 or 11 on the first roll wins
+2. A 2, 3, or 12 on the first roll loses
+3. Any other number rolled becomes your “point.”
+    - You continue to roll, if you get your point, you win.
+    - If you roll a 7, you lose and the dice change hands when this happens.
+
+This version of craps was modified by Steve North of Creative Computing. It is based on an original which appeared one day on a computer at DEC.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=52)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=67)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/30_Cube/README.md
+++ b/30_Cube/README.md
@@ -1,7 +1,14 @@
 ### Cube
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=53
+CUBE is a game played on the facing sides of a cube with a side dimension of 2. A location is designated by three numbers — e.g., 1, 2, 1. The object is to travel from 1, 1, 1 to 3, 3, 3 by moving one horizontal or vertical (not diagonal) square at a time without striking one of 5 randomly placed landmines. You are staked to $500; prior to each play of the game you may make a wager whether you will reach your destination. You lose if you hit a mine or try to make an illegal move — i.e., change more than one digit from your previous position.
+
+Cube was created by Jerimac Ratliff of Fort Worth, Texas.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=53)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=68)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/31_Depth_Charge/README.md
+++ b/31_Depth_Charge/README.md
@@ -1,7 +1,16 @@
 ### Depth Charge
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=55
+In this program you are captain of the destroyer USS Computer. An enemy submarine has been causing trouble and your mission is to destroy it. You may select the seize of the “cube” of water you wish to search in. The computer then determines how many depth charges you get to destroy the submarine.
+
+Each depth charge is exploded by you specifying a trio of numbers; the first two are the surface coordinates (X,Y), the third is the depth. After each depth charge, your sonar observer will tell you where the explosion was relative to the submarine.
+
+Dana Noftle wrote this program while a student at Acton High School, Acton, Massachusetts.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=55)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=70)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/32_Diamond/README.md
+++ b/32_Diamond/README.md
@@ -1,7 +1,14 @@
 ### Diamond
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=56
+This program fills an 8.5x11 piece of paper with diamonds (plotted on a hard-copy terminal, of course). The program asks for an odd number to be input in the range 5 to 31. The diamonds printed will be this number of characters high and wide. The number of diamonds across the page will vary from 12 for 5-character wide diamonds to 1 for a diamond 31-characters wide. You can change the content of the pattern if you wish.
+
+The program was written by David Ahl of Creative Computing.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=56)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=71)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/33_Dice/README.md
+++ b/33_Dice/README.md
@@ -1,7 +1,21 @@
 ### Dice
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=57
+Not exactly a game, this program simulates rolling a pair of dice a large number of times and prints out the frequency distribution. You simply input the number of rolls. It is interesting to see how many rolls are necessary to approach the theoretical distribution:
+
+|   |      |            |
+|---|------|------------|
+| 2 | 1/36 | 2.7777...% |
+| 3 | 2/36 | 5.5555...% |
+| 4 | 3/36 | 8.3333...% |
+etc.
+
+Daniel Freidus wrote this program while in the seventh grade at Harrison Jr-Sr High School, Harrison, New York.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=57)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=72)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/34_Digits/README.md
+++ b/34_Digits/README.md
@@ -1,7 +1,17 @@
 ### Digits
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=58
+The player writes down a set of 30 numbers (0, 1, or 2) at random prior to playing the game. The computer program, using pattern recognition techniques, attempts to guess the next number in your list.
+
+The computer asks for 10 numbers at a time. It always guesses first and then examines the next number to see if it guessed correctly. By pure luck (or chance or probability), the computer ought to be right 10 times. It is uncanny how much better it generally does than that!
+
+This program originated at Dartmouth; original author unknown.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=58)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=73)
+
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/35_Even_Wins/README.md
+++ b/35_Even_Wins/README.md
@@ -1,7 +1,18 @@
 ### Even Wins
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=60
+This is a game between you and the computer. To play, an odd number of objects (marbles, chips, matches) are placed in a row. You take turns with the computer picking up between one and four objects each turn. The game ends when there are no objects left, and the winner is the one with an even number of objects picked up.
+
+Two versions of this game are included. While to the player they appear similar, the programming approach is quite different. EVEN WINS, the first version, is deterministic — i.e., the computer plays by fixed, good rules and is impossible to beat if you don’t know how to play the game. It always starts with 27 objects, although you may change this.
+
+The second version, GAME OF EVEN WINS, is much more interesting because the computer starts out only knowing the rules of the game. Using simple techniques of artificial intelligence (cybernetics), the computer gradually learns to play this game from its mistakes until it plays a very good game. After 20 games, the computer is a challenge to beat. Variation in the human’s style of play seems to make the computer learn more quickly. If you plot the learning curve of this program, it closely resembles classical human learning curves from psychological experiments.
+
+Eric Peters at DEC wrote the GAME OF EVEN WINS. The original author of EVEN WINS is unknown.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=60)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=75)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/36_Flip_Flop/README.md
+++ b/36_Flip_Flop/README.md
@@ -1,7 +1,28 @@
 ### Flip Flop
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=63
+The object of this game is to change a row of ten X’s
+
+```
+X X X X X X X X X X
+```
+
+to a row of ten 0’s
+
+```
+0 0 0 0 0 0 0 0 0 0
+```
+
+by typing in a number corresponding to the position of an “X” in the line. On some numbers one position will change while on other numbers, two will change. For example, inputting a 3 may reverse the X and 0 in position 3, but it might possibly reverse some of other position too! You ought to be able to change all 10 in 12 or fewer moves. Can you figure out a good winning strategy?
+
+To reset the line to all X’s (same game), type 0 (zero). To start a new game at any point, type 11.
+
+The original author of this game was Micheal Kass of New Hyde Park, New York.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=63)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=78)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/37_Football/README.md
+++ b/37_Football/README.md
@@ -1,7 +1,18 @@
 ### Football
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=64
+Football is probably the most popular simulated sports game. I have seen some people play to elect to play computerized football in preference to watching a football game on television.
+
+Two versions of football are presented. The first is somewhat “traditional” in that you, the player, are playing against the computer. You have a choice of seven offensive plays. On defense the computer seems to play a zone defence, but you have no choice of plays. The computer program presents the necessary rules as you play, and it is also the referee and determines penalties when an infraction is committed. FTBALL was written by John Kemeny at Dartmouth.
+
+IN the second version of football, the computer referees a game played between two human players. Each player gets a list of twenty plays with a code value for each one. This list should be kept confidential from your opponent. The codes can be changes in data. All twenty plays are offensive; a defensive play is specified by defending against a type of offensive play. A defense is good for other similar types of plays, for example, a defense against a flare pass is very good against a screen pass but much less good against a half-back option.
+
+This game was originally written by Raymond Miseyka of Butler, Pennsylvania.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=64)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=79)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/38_Fur_Trader/README.md
+++ b/38_Fur_Trader/README.md
@@ -1,7 +1,16 @@
 ### Fur Trader
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=69
+You are the leader of a French fur trading expedition in 1776 leaving the Ontario area to sell furs and get supplies for the next year. You have a choice of three forts at which you may trade. The cost of supplies and the amount you recieve for your furs will depend upon the fort you choose. You also specify what types of furs that you have to trade.
+
+The game goes on and on until you elect to trade no longer.
+
+Author of the program is Dan Bachor, University of Calgary, Alberta, Canada.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=69)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=84)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/39_Golf/README.md
+++ b/39_Golf/README.md
@@ -1,7 +1,15 @@
 ### Golf
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=71
+This is a single player golf game. In other words it’s you against the golf course (the computer). The program asks for your handicap (maximum of 30) and your area of difficulty. You have a bag of 29 clubs plus a putter. On the course you have to contend with rough, trees, on and off fairway, sand traps, and water hazards. In addition, you can hook, slice, go out of bounds, or hit too far. On putting, you determine the potency factor (or percent of swing). Until you get the swing of the game (no pun intended), you’ll probably was to use a fairly high handicap.
+
+Steve North of Creative Computing modified the original version of this game, the author of which is unknown.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=71)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=86)
+
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/40_Gomoko/README.md
+++ b/40_Gomoko/README.md
@@ -1,7 +1,16 @@
 ### Gomoko
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=74
+GOMOKO or GOMOKU is a traditional game of the Orient. It is played by two people on a board of intersecting lines (19 left-to-right lines, 19 top-to-bottom lines, 361 intersections in all). Players take turns. During his turn, a player may cover one intersection with a marker; (one player uses white markers; the other player uses black markers). The object of the game is to get five adjacent markers in a row, horizontally, vertically or along either diagonal.
+
+Unfortunately, this program does not make the computer a very good player. It does not know when you are about to win or even who has won. But some of its moves may surprise you.
+
+The original author of this program is Peter Sessions of People’s Computer Company.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=74)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=89)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/41_Guess/README.md
+++ b/41_Guess/README.md
@@ -1,7 +1,16 @@
 ### Guess
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=75
+In Program GUESS, the computer chooses a random integer between 0 and any limit you set. You must then try to guess the number the computer has chosen using the clues provided by the computer.
+
+You should be able to guess the number in one less than the number of digits needed to represent the number in binary notation — i.e., in base 2. This ought to give you a clue as to the optimum search technique.
+
+GUESS converted from the original program in FOCAL which appeared in the book “Computers in the Classroom” by Walt Koetke of Lexington High School, Lexington, Massachusetts.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=75)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=90)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/42_Gunner/README.md
+++ b/42_Gunner/README.md
@@ -1,7 +1,16 @@
 ### Gunner
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=77
+GUNNER allows you to adjust the fire of a field artillery weapon to hit a stationary target. You specify the number of degrees of elevation of your weapon; 45 degrees provides maximum range with values under or over 45 degrees providing less range.
+
+You get up to five shots to destroy the enemy before he destroys you. Gun range varies between 20,000 and 60,000 yards and burst radius is 100 yards. You must specify elevation within approximately 0.2 degrees to get a hit.
+
+Tom Kloos of the Oregon Museum of Science and Industry in Portland, Oregon originally wrote GUNNER. Extensive modifications were added by David Ahl.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=77)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=92)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/43_Hammurabi/README.md
+++ b/43_Hammurabi/README.md
@@ -1,7 +1,22 @@
 ### Hammurabi
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=78
+In this game you direct the administrator of Sumeria, Hammurabi, how to manage the city. The city initially has 1,000 acres, 100 people and 3,000 bushels of grain in storage.
+
+You may buy and sell land with your neighboring city-states for bushels of grain — the price will vary between 17 and 26 bushels per acre. You also must use grain to feed your people and as seed to plant the next year’s crop.
+
+You will quickly find that a certain number of people can only tend a certain amount of land and that people starve if they are not fed enough. You also have the unexpected to contend with such as a plague, rats destroying stored grain, and variable harvests.
+
+You will also find that managing just the few resources in this game is not a trivial job over a period of say ten years. The crisis of population density rears its head very rapidly.
+
+This program was originally written in Focal at DEC; author unknown. David Ahl converted it to BASIC and added the 10-year performance assessment. If you wish to change any of the factors, the extensive remarks in the program should make modification fairly straightforward.
+
+Note for trivia buffs: somewhere along the line an m was dropped out of the spelling of Hammurabi in hte Ahl version of the computer program. This error has spread far and wide until a generation of students now think that Hammurabi is the incorrect spelling.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=78)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=93)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/44_Hangman/README.md
+++ b/44_Hangman/README.md
@@ -1,7 +1,26 @@
 ### Hangman
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=80
+This is a simulation of the word guessing game, hangman. The computer picks a word, tells you how many letters in the word it has picked and then you guess a letter in the word. If you are right, the computer tells you where that letter belongs; if your letter is wrong, the computer starts to hang you. You get ten guesses before you are completely hanged:
+1. Head
+2. Body
+3. Right Arm
+4. Left Arm
+5. Right Leg
+6. Left Leg
+7. Right Hand
+8. Left Hand
+9. Right Foot
+10. Left Foot
+
+You may add words in Data statements; however if you do, you must also change the random word selector.
+
+David Ahl modified this program into its current form from the one created by Kenneth Aupperle of Melville, New York.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=80)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=95)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/45_Hello/README.md
+++ b/45_Hello/README.md
@@ -1,7 +1,16 @@
 ### Hello
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=82
+This is a sample of one of the great number of conversational programs. In a sense, it is like a CAI program except that its responses are just good fun. Whenever a computer is exhibited at a convention or conference with people that have not used a computer before, the conversational programs seem to get the first activity.
+
+In this particular program, the computer dispenses advice on various problems such as sex. health, money, or job.
+
+David Ahl is the author of HELLO.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=82)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=97)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/46_Hexapawn/README.md
+++ b/46_Hexapawn/README.md
@@ -1,7 +1,16 @@
 ### Hexapawn
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=83
+The game of Hexapawn and a method to learn a strategy for playing the game was described in Martin Gardner’s “Mathematical Games” column in the March 1962 issue of _Scientific American_. The method described in the article was for a hypothetical learning machine composed of match boxes and colored beads. This has been generalized in the program HEX.
+
+The program learns by elimination of bad moves. All positions encountered by the program and acceptable moves from them are stored in an array. When the program encounters an unfamiliar position, the position and all legal moves from it are added to the list. If the program loses a game, it erases the move that led to defeat. If it hits a position from which all moves have been deleted (they all led to defeat), it erases the move that got it there and resigns. Eventually, the program learns to play extremely well and, indeed, is unbeatable. The learning strategy could be adopted to other simple games with a finite number of moves (tic-tac-toe, small board checkers, or other chess-based games).
+
+The original version of this program was written by R.A. Kaapke. It was subsequently modified by Jeff Dalton and finally by Steve North of Creative Computing.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=83)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=98)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/47_Hi-Lo/README.md
+++ b/47_Hi-Lo/README.md
@@ -1,7 +1,21 @@
 ### Hi-Lo
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=85
+This game is an adaptation of the game GUESS; however, instead of just guessing a number between 1 and 100, in this game you win dollars when you guess the number. The directions, in the words of the author, are as follows:
+1. There is an amount of money, between one and one hundred dollars, in the “HI-LO” jackpot.
+2. You will have six chances in which to guess the amount of money in the jackpot.
+3. After each guess, the computer will tell whether the guess was too high or too low.
+4. If the correct amount of money is not guessed after six chances, the computer will print the amount in the jackpot.
+5. If the correct amount of money is guessed within the six chance limit, the computer will register this amount.
+6. After each sequence of guesses, you have the choice of playing again or ending the program. If a new game is played, a new amount of money will constitute the jackpot.
+7. If youwin more than once, then your earnings are totalled.
+
+The author is Dean ALtman of Fort Worth, Texas.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=85)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=100)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/48_High_IQ/README.md
+++ b/48_High_IQ/README.md
@@ -1,7 +1,16 @@
 ### High IQ
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=86
+This is a computerized version of an old European solitaire game of logic. The game starts with a pegboard shaped like a cross having pegs in every hole but the center. The object is to remove all 32 pegs, or as many as possible, by jumping into an empty hole, then removing the jumped peg.
+
+There are several different winning strategies for playing, and of course, each strategy can be played eight different ways on the board. Can you find a consistent winner?
+
+Charles Lund wrote this game while at The American School in The Hague, Netherlands.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=86)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=101)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/49_Hockey/README.md
+++ b/49_Hockey/README.md
@@ -1,7 +1,16 @@
 ### Hockey
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=88
+This is a simulation of a ice hockey game. The computer, in this case, moderates and referees the pay between two human opponents. Of course, one person could play both sides.
+
+The program asks for team names, player names, and even the name of the referee. Four types of shot are permitted and a shot may be aimed at one of four areas. You are also asked about passing. The game is very comprehensive with lots of action, face offs, blocks, passes, 4 on 2 situations, and so on. Unfortunately there are no penalties.
+
+The original author is Robert Puopolo; modifications by Steve North of Creative Computing.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=88)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=103)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/50_Horserace/README.md
+++ b/50_Horserace/README.md
@@ -1,7 +1,14 @@
 ### Horserace
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=92
+This program simulates a one-mile horse race for three-year old throughbreds. Up to ten people may place bets on the race up to $10,000 each. However, you may only bet to win. You place your bet by inputting the number of the horse, a comma, and the amount of your bet. The computer then shows the position of the horses at seven points around the track and at the finish. Payoffs and winnings are shown at the end.
+
+The program was written by Laurie Chevalier while a student at South Portland High School.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=92)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=107)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/51_Hurkle/README.md
+++ b/51_Hurkle/README.md
@@ -1,7 +1,16 @@
 ### Hurkle
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=94
+Hurkle? A Hurkle is a happy beast and lives in another galaxy on a planet named Lirht that has three moons. Hurkle are favorite pets of the Gwik, the dominant race of Lihrt and … well, to find out more, read “The Hurkle is a Happy Beast,” a story in the book _A Way Home_ by Theodore Sturgeon.
+
+In this program a shy hurkle is hiding on a 10 by 10 grid. Homebase is point 0,0 in the _Southwest_ corner. Your guess as to the gridpoint where the hurkle is hiding should be a pair of whole numbers, separated by a comma. After each try, the computer will tell you the approximate direction to go look for the Hurkle. You get five guesses to find him; you may change this number, although four guesses is actually enough.
+
+This program was written by Bob Albrecht of People’s Computer Company.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=94)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=109)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/52_Kinema/README.md
+++ b/52_Kinema/README.md
@@ -1,7 +1,19 @@
 ### Kinema
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=95
+This program tests your fundamental knowledge of kinematics. It presents a simple problem: a ball is thrown straight up into the air at some random velocity. You then must answer three questions about the flight of the ball:
+1. How high will it go?
+2. How long until it returns to earth?
+3. What will be its velocity after a random number of seconds?
+
+The computer evaluates your performance; within 15% of the correct answer is considered close enough. After each run, the computer gives you another problem until you interrupt it.
+
+KINEMA was shorted from the original Huntington Computer Project Program, KINERV, by Richard Pav of Patchogue High School, Patchogue, New York.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=95)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=110)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/53_King/README.md
+++ b/53_King/README.md
@@ -1,7 +1,18 @@
 ### King
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=96
+This is one of the most comprehensive, difficult, and interesting games. (If you’ve never played one of these games, start with HAMMURABI.)
+
+In this game, you are Premier of Setats Detinu, a small communist island 30 by 70 miles long. Your job is to decide upon the budget of your country and distribute money to your country from the communal treasury.
+
+The money system is Rollods; each person needs 100 Rallods per year to survive. Your country’s income comes from farm produce and tourists visiting your magnificent forests, hunting, fishing, etc. Part of your land is farm land but it also has an excellent mineral content and may be sold to foreign industry for strip mining. Industry import and support their own workers. Crops cost between 10 and 15 Rallods per square mile to plant, cultivate, and harvest. Your goal is to complete an eight-year term of office without major mishap. A word of warning: it isn’t easy!
+
+The author of this program is James A. Storer who wrote it while a student at Lexington High School.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=96)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=111)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/54_Letter/README.md
+++ b/54_Letter/README.md
@@ -1,7 +1,14 @@
 ### Letter
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=99
+LETTER is similar to the game GUESS in which you guess a number chosen by the computer; in this program, the computer picks a random letter of the alphabet and you must guess which one it is using the clues provided as you go along. It should not take you more than five guesses to get the mystery letter.
+
+The program which appears here is loosely based on the original written by Bob Albrect of People’s Computer Company.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=99)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=114)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/55_Life/README.md
+++ b/55_Life/README.md
@@ -1,7 +1,35 @@
 ### Life
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=100
+The Game of Life was originally described in _Scientific American_, October 1970, in an article by Martin Gardner. The game itself was originated by John Conway of Gonville and Caius College, University of Cambridge England.
+
+In the “manual” game, organisms exist in the form of counters (chips or checkers) on a large checkerboard and die or reproduce according to some simple genetic rules. Conway’s criteria for choosing his genetic laws were carefully delineated as follows:
+1. There should be no initial pattern for which there is a simple proof that the population can grow without limit.
+2. There should be simple initial patterns that apparently do grow without limit.
+3. There should be simple initial patterns that grow and change for a considerable period of time before coming to an end in three possible ways:
+    1. Fading away completely (from overcrowding or from becoming too sparse)
+    2. Settling into a stable configuration that remains unchanged thereafter
+    3. Entering an oscillating phase in which they repeat an endless cycle of two or more periods
+
+In brief, the rules should be such as to make the behavior of the population relatively unpredictable. Conway’s genetic laws are delightfully simple. First note that each cell of the checkerboard (assumed to be an infinite plane) has eight neighboring cells, four adjacent orthogonally, four adjacent diagonally. The rules are:
+1. Survivals. Every counter with two or three neighboring counters survives for the next generation.
+2. Deaths. Each counter with four or more neighbors dies (is removed) from overpopulation. Every counter with one neighbor or none dies from isolation.
+3. Births. Each empty cell adjacent to exactly three neighbors — no more — is a birth cell. A counter is placed on it at the next move.
+
+It is important to understand that all births and deaths occur simultaneously. Together they constitute a single generation or, as we shall call it, a “move” in the complete “life history” of the initial configuration.
+
+You will find the population constantly undergoing unusual, sometimes beautiful and always unexpected change. In a few cases the society eventually dies out (all counters vanishing), although this may not happen until after a great many generations. Most starting patterns either reach stable figures — Conway calls them “still lifes” — that cannot change or patterns that oscillate forever. Patterns with no initial symmetry tend to become symmetrical. Once this happens the symmetry cannot be lost, although it may increase in richness.
+
+Conway used a DEC PDP-7 with a graphic display to observe long-lived populations. You’ll probably find this more enjoyable to watch on a CRT than a hard-copy terminal.
+
+Since MITS 8K BASIC does not have LINE INPUT, to enter leading blanks in the patter, type a “.” at the start of the line. This will be converted to a space by BASIC, but it permits you to type leading spaces. Typing DONE indicates that you are finished entering the pattern. See sample run.
+
+Clark Baker of Project DELTA originally wrote this version of LIFE which was further modified by Steve North of Creative Computing.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=100)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=115)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/56_Life_for_Two/README.md
+++ b/56_Life_for_Two/README.md
@@ -1,7 +1,44 @@
 ### Life for Two
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=102
+LIFE-2 is based on Conway’s game of Life. You must be familiar with the rules of LIFE before attempting to play LIFE-2.
+
+There are two players; the game is played on a 5x5 board and each player has a symbol to represent his own pieces of ‘life.’ Live cells belonging to player 1 are represented by `*` and live cells belonging to player 2 are represented by the symbol `#`.
+
+The # and * are regarded as the same except when deciding whether to generate a live cell. An empty cell having two `#` and one `*` for neighbors will generate a `#`, i.e. the live cell generated belongs to the player who has the majority of the 3 live cells surrounding the empty cell where life is to be generated, for example:
+
+|   | 1 | 2 | 3 | 4 | 5 |
+|:-:|:-:|:-:|:-:|:-:|:-:|
+| 1 |   |   |   |   |   |
+| 2 |   |   | * |   |   |
+| 3 |   |   |   | # |   |
+| 4 |   |   | # |   |   |
+| 5 |   |   |   |   |   |
+
+A new cell will be generated at (3,3) which will be a `#` since there are two `#` and one `*` surrounding. The board will then become:
+
+|   | 1 | 2 | 3 | 4 | 5 |
+|:-:|:-:|:-:|:-:|:-:|:-:|
+| 1 |   |   |   |   |   |
+| 2 |   |   |   |   |   |
+| 3 |   |   | # | # |   |
+| 4 |   |   |   |   |   |
+| 5 |   |   |   |   |   |
+
+On the first most each player positions 3 pieces of life on the board by typing in the co-ordinates of the pieces. (In the event of the same cell being chosen by both players that cell is left empty.)
+
+The board is then adjusted to the next generation and printed out.
+
+On each subsequent turn each player places one piece on the board, the object being to annihilate his opponent’s pieces. The board is adjusted for the next generation and printed out after both players have entered their new piece.
+
+The game continues until one player has no more live pieces. The computer will then print out the board and declare the winner.
+
+The idea for this game, the game itself, and the above write-up were written by Brian Wyvill of Bradford University in Yorkshire, England.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=102)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=117)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/57_Literature_Quiz/README.md
+++ b/57_Literature_Quiz/README.md
@@ -1,7 +1,14 @@
 ### Literature Quiz
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=104
+This is a simple CAI-type program which presents four multiple-choice questions from children’s literature. Running the program is self-explanatory.
+
+The program was written by Pamela McGinley while at DEC.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=104)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=117)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/58_Love/README.md
+++ b/58_Love/README.md
@@ -1,7 +1,14 @@
 ### Love
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=105
+This program is designed to reproduce Robert Indiana’s great art work “Love” with a message of your choice up to 60 characters long.
+
+The love program was created by David Ahl.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=105)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=120)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/59_Lunar_LEM_Rocket/README.md
+++ b/59_Lunar_LEM_Rocket/README.md
@@ -1,7 +1,24 @@
 ### Lunar LEM Rocket
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=106
+This game in its many different versions and names (ROCKET, LUNAR, LEM, and APOLLO) is by far and away the single most popular computer game. It exists in various versions that start you anywhere from 500 feet to 200 miles away from the moon, or other planets, too. Some allow the control of directional stabilization rockets and/or the retro rocket. The three versions presented here represent the most popular of the many variations.
+
+In most versions of this game, the temptation is to slow up too soon and then have no fuel left for the lower part of the journey. This, of course, is disastrous (as you will find out when you land your own capsule)!
+
+LUNAR was originally in FOCAL by Jim Storer while a student at Lexington High School and subsequently converted to BASIC by David Ahl. ROCKET was written by Eric Peters at DEC and LEM by William Labaree II of Alexandria, Virginia.
+
+In this program, you set the burn rate of the retro rockets (pounds of fuel per second) every 10 seconds and attempt to achieve a soft landing on the moon. 200 lbs/sec really puts the brakes on, and 0 lbs/sec is free fall. Ignition occurs a 8 lbs/sec, so _do not_ use burn rates between 1 and 7 lbs/sec. To make the landing more of a challenge, but more closely approximate the real Apollo LEM capsule, you should make the available fuel at the start (N) equal to 16,000 lbs, and the weight of the capsule (M) equal to 32,500 lbs.
+
+#### LEM
+This is the most comprehensive of the three versions and permits you to control the time interval of firing, the thrust, and the attitude angle. It also allows you to work in the metric or English system of measurement. The instructions in the program dialog are very complete, so you shouldn’t have any trouble.
+
+#### ROCKET
+In this version, you start 500 feet above the lunar surface and control the burn rate in 1-second bursts. Each unit of fuel slows your descent by 1 ft/sec. The maximum thrust of your engine is 30 ft/sec/sec.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=106)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=121)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/60_Mastermind/README.md
+++ b/60_Mastermind/README.md
@@ -1,7 +1,29 @@
 ### MasterMind
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=110
+In that Match-April 1976 issue of _Creative_ we published a computerized version of Master Mind, a logic game. Master Mind is played by two people—one is called the code-maker; the other, the code-breaker. At the beginning of the game the code-maker forms a code, or combination of colored pegs. He hides these from the code-breaker. The code-breaker then attempts to deduce the code, by placing his own guesses, one at a time, on the board. After he makes a guess (by placing a combination of colored pegs on the board) the code-maker then gives the code-breaker clues to indicate how close the guess was to the code. For every peg in the guess that’s the right color but not in the right position, the code-breaker gets a white peg. Note that these black and white pegs do not indicate _which_ pegs in the guess are correct, but merely that they exist. For example, if the code was:
+```
+Yellow Red Red Green
+```
+
+and my guess was
+```
+Red Red Yellow Black
+```
+I would receive two white pegs and one black peg for the guess. I wouldn’t know (except by comparing previous guesses) which one of the pegs in my guess was the right color in the right position.
+
+Many people have written computer programs to play Master Mind in the passive role, i.e., the computer is the code maker and the human is the code-breaker. This is relatively trivial; the challenge is writing a program that can also play actively as a code-breaker.
+
+Actually, the task of getting the computer to deduce the correct combination is not at all difficult. Imagine, for instance, that you made a list of all possible codes. To begin, you select a guess from your list at random. Then, as you receive clues, you cross off from the list those combinations which you know are impossible. For example if your guess is Red Red Green Green and you receive no pegs, then you know that any combination containing either a red or a green peg is impossible and may be crossed of the list. The process is continued until the correct solution is reached or there are no more combinations left on the list (in which case you know that the code-maker made a mistake in giving you the clues somewhere).
+
+Note that in this particular implementation, we never actually create a list of the combinations, but merely keep track of which ones (in sequential order) may be correct. Using this system, we can easily say that the 523rd combination may be correct, but to actually produce the 523rd combination we have to count all the way from the first combination (or the previous one, if it was lower than 523). Actually, this problem could be simplified to a conversion from base 10 to base (number of colors) and then adjusting the values used in the MID$ function so as not to take a zeroth character from a string if you want to experiment. We did try a version that kept an actual list of all possible combinations (as a string array), which was significantly faster than this version, but which ate tremendous amounts of memory.
+
+At the beginning of this game, you input the number of colors and number of positions you wish to use (which will directly affect the number of combinations) and the number of rounds you wish to play. While you are playing as the code-breaker, you may type BOARD at any time to get a list of your previous guesses and clues, and QUIT to end the game. Note that this version uses string arrays, but this is merely for convenience and can easily be converted for a BASIC that has no string arrays as long as it has a MID$ function. This is because the string arrays are one-dimensional, never exceed a length greater than the number of positions and the elements never contain more than one character.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=110)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=125)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/61_Math_Dice/README.md
+++ b/61_Math_Dice/README.md
@@ -1,7 +1,14 @@
 ### Math Dice
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=113
+The program presents pictorial drill on addition facts using printed dice with no reading involved. It is good for beginning addition, since the answer can be derived from counting spots on the dice as well as by memorizing math facts or awareness of number concepts. It is especially effective run on a CRT terminal.
+
+It was originally written by Jim Gerrish, a teacher at the Bernice A. Ray School in Hanover, New Hampshire.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=113)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=128)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/62_Mugwump/README.md
+++ b/62_Mugwump/README.md
@@ -1,7 +1,18 @@
 ### Mugwump
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=114
+Your objective in this game is to find the four Mugwumps hiding on various squares of a 10 by 10 grid. Homebase (lower left) is position (0,0) and a guess is a pair of whole numbers (0 to 9), separated by commas. The first number is the number of units to the right of homebase and the second number is the distance above homebase.
+
+You get ten guesses to locate the four Mugwumps; after each guess, the computer tells you how close you are to each Mugwump. Playing the game with the aid of graph paper and a compass should allow you to find all the Mugwumps in six or seven moves using triangulation similar to Loran radio navigation.
+
+If you want to make the game somewhat more difficult, you can print the distance to each Mugwump either rounded or truncated to the nearest integer.
+
+This program was modified slightly by Bob Albrecht of People’s Computer Company. It was originally written by students of Bud Valenti of Project SOLO in Pittsburg, Pennsylvania.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=114)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=129)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/63_Name/README.md
+++ b/63_Name/README.md
@@ -1,7 +1,14 @@
 ### Name
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=116
+NAME is a silly little ice-breaker to get a relationship going between a computer and a shy human. The sorting algorithm used is highly inefficient — as any reader of _Creative Computing_ will recognize, this is the worst possible sort for speed. But the program is good fun and that’s what counts here.
+
+NAME was originall written by Geoffry Chase of the Abbey, Portsmouth, Rhode Island.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=116)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=131)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/63_Name/README.md
+++ b/63_Name/README.md
@@ -2,7 +2,7 @@
 
 NAME is a silly little ice-breaker to get a relationship going between a computer and a shy human. The sorting algorithm used is highly inefficient — as any reader of _Creative Computing_ will recognize, this is the worst possible sort for speed. But the program is good fun and that’s what counts here.
 
-NAME was originally written by Geoffry Chase of the Abbey, Portsmouth, Rhode Island.
+NAME was originally written by Geoffrey Chase of the Abbey, Portsmouth, Rhode Island.
 
 ---
 

--- a/63_Name/README.md
+++ b/63_Name/README.md
@@ -2,7 +2,7 @@
 
 NAME is a silly little ice-breaker to get a relationship going between a computer and a shy human. The sorting algorithm used is highly inefficient — as any reader of _Creative Computing_ will recognize, this is the worst possible sort for speed. But the program is good fun and that’s what counts here.
 
-NAME was originall written by Geoffry Chase of the Abbey, Portsmouth, Rhode Island.
+NAME was originally written by Geoffry Chase of the Abbey, Portsmouth, Rhode Island.
 
 ---
 

--- a/64_Nicomachus/README.md
+++ b/64_Nicomachus/README.md
@@ -1,7 +1,18 @@
 ### Nicomachus
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=117
+One of the most ancient forms of arithmetic puzzle is sometimes referred to as a “boomerang.” At some time, everyone has been asked to “think of a number,” and, after going through some process of private calculation, to state the result, after which the questioner promptly tells you the number you originally thought of. There are hundreds of varieties of this puzzle.
+
+The oldest recorded example appears to be that given in _Arithmetica_ of Nicomachus, who died about the year 120. He tells you to think of any whole number between 1 and 100 and divide it successfully by 3, 5, and 7, telling him the remainder in each case. On receiving this information, he promptly discloses the number you thought of.
+
+Can you discover a simple method of mentally performing this feat? If not, you can see how the ancient mathematician did it by looking at this program.
+
+Nicomachus was written by David Ahl.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=117)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=132)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/65_Nim/README.md
+++ b/65_Nim/README.md
@@ -1,7 +1,27 @@
 ### Nim
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=118
+NIM is one of the oldest two-person games known to man; it is believed to have originated in ancient China. The name, which was coined by the first mathematician to analyze it, comes from an archaic English verb which means to steal or to take away. Objects are arranged in rows between the two opponents as in the following example:
+|         |       |           |
+|---------|-------|-----------|
+| XXXXXXX | Row 1 | 7 Objects |
+| XXXXX   | Row 2 | 5 Objects |
+| XXX     | Row 3 | 3 Objects |
+| X       | Row 4 | 1 Object  |
+
+Opponents take turns removing objects until there are none left. The one who picks up the last object wins. The moves are made according to the following rules:
+1. On any given turn only objects from one row may be removed. There is no restriction on which row or on how many objects you remove. Of course, you cannot remove more than are in the row.
+2. You cannot skip a move or remove zero objects.
+
+The winning strategy can be mathematically defined, however, rather than presenting it here, we’d rather let you find it on your own. HINT: Play a few games with the computer and mark down on a piece of paper the number of objects in each stack (in binary!) after each move. Do you see a pattern emerging?
+
+This game of NIM is from Dartmouth College and allows you to specify any starting size for the four piles and also a win option. To play traditional NIM, you would simply specify 7,5,3 and 1, and win option 1.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=118)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=133)
+
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/66_Number/README.md
+++ b/66_Number/README.md
@@ -1,7 +1,14 @@
 ### Number
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=121
+In contrast to other number guessing games where you keep guessing until you get the random number selected by the computer (GUESS, TRAP, STARS, etc.), in this game you only get one guess per play and you gain or lose points depending upon how close your guess is to the random number selected by the computer. You occasionally get a jackpot which will double your point count. You win when you get 500 points.
+
+Tom Adametx wrote this program while a student at Curtis Junior High School in Sudbury, Massachusetts.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=121)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=136)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/67_One_Check/README.md
+++ b/67_One_Check/README.md
@@ -1,7 +1,29 @@
 ### One Check
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=122
+In this game or puzzle, 48 checkers are placed on the two outside spaces of a standard 64-square checkerboard as shown:
+
+|   |   |   |   |   |   |   |   |
+|---|---|---|---|---|---|---|---|
+| ● | ● | ● | ● | ● | ● | ● | ● |
+| ● | ● | ● | ● | ● | ● | ● | ● |
+| ● | ● |   |   |   |   | ● | ● |
+| ● | ● |   |   |   |   | ● | ● |
+| ● | ● |   |   |   |   | ● | ● |
+| ● | ● |   |   |   |   | ● | ● |
+| ● | ● | ● | ● | ● | ● | ● | ● |
+| ● | ● | ● | ● | ● | ● | ● | ● |
+
+The object is to remove as many checkers as possible by diagonal jumps (as in standard checkers).
+
+It is easy to remove 30 to 39 checkers, a challenge to remove 40 to 44, and a substantial feat to remove 45 to 47.
+
+The program was created and written by David Ahl.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=122)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=137)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/68_Orbit/README.md
+++ b/68_Orbit/README.md
@@ -1,7 +1,57 @@
 ### Orbit
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=124
+ORBIT challenges you to visualize spacial positions in polar coordinates. The object is to detonate a Photon explosive within a certain distance of a germ laden Romulan spaceship. This ship is orbiting a planet at a constant altitude and orbital rate (degrees/hour). The location of the ship is hidden by a device that renders the ship invisible, but after each bomb you are told how close to the enemy ship your bomb exploded. The challenge is to hit an invisible moving target with a limited number of shots.
+
+The planet can be replaced by a point at its center (called the origin); then the ship’s position can be given as a distance form the origin and an angle between its position and the eastern edge of the planet.
+
+```
+direction
+of orbit    <       ^ ship
+              \     ╱
+                \  ╱ <
+                 |╱   \
+                 ╱      \
+                ╱         \
+               ╱           | angle
+              ╱           /
+             ╱          /
+            ╱         /
+           ╱——————————————————— E
+
+```
+
+The distance of the bomb from the ship is computed using the law of consines. The law of cosines states:
+
+```
+D = SQUAREROOT( R**2+D1**2+R*D1*COS(A-A1) )
+```
+
+Where D is the distance between the ship and the bomb, R is the altitude of the ship, D1 is the altitude of the bomb, and A-A1 is the angle between the ship and the bomb.
+
+
+```
+                 bomb  <
+                        ╲                   ^ ship
+                         ╲                  ╱
+                          ╲                ╱ <
+                           ╲              ╱   \
+                        D1  ╲            ╱      \
+                             ╲        R ╱         \
+                              ╲   A1   ╱           | A
+                               ╲⌄——— ◝╱           /
+                                ╲    ╱ \        /
+                                 ╲  ╱   \      /
+                                  ╲╱───────────────────── E
+
+```
+
+ORBIT was originally called SPACE WAR and was written by Jeff Lederer of Project SOLO Pittsburgh, Pennsylvania.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=124)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=139)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/69_Pizza/README.md
+++ b/69_Pizza/README.md
@@ -1,7 +1,16 @@
 ### Pizza
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=126
+In this game, you take orders for pizzas from people living in Hyattsville. Armed with a map of the city, you must then tell your delivery boy the address where the pizza is to be delivered. If the pizza is delivered to the correct address, the customer phones you and thanks you; if not, you must give the driver the correct address until the pizza gets delivered.
+
+Some interesting modifications suggest themselves for this program such as pizzas getting cold after two incorrect delivery attempts or taking three or more orders at a time and figuring out the shortest delivery route. Send us your modifications!
+
+This program seems to have surfaced originally at the University of Georgia in Athens, Georgia. The author is unknown.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=126)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=141)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/70_Poetry/README.md
+++ b/70_Poetry/README.md
@@ -1,7 +1,29 @@
 ### Poetry
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=128
+This program produces random verse which might loosely be considered in the Japanese Haiku style. It uses 20 phrases in four groups of five phrases each and generally cycles through the groups in order. It inserts commas (random — 19% of the time), indentation (random — 22% of the time), and starts new paragraphs (18% probability but at least once every 20 phrases).
+
+The phrases in POETRY are somewhat suggestive of Edgar Allen Poe. Try it with phrases from computer technology, from love and romance, from four-year-old children, or from some other project. Send us the output.
+
+Here are some phrases from nature to try:
+```
+Carpet of ferns     Mighty Oaks
+Morning dew         Grace and beauty
+Tang of dawn        Silently singing
+Swaying pines       Nature speaking
+
+Entrances me        Untouched, unspoiled
+Soothing me         Shades of green
+Rustling leaves     Tranquility
+Radiates calm       …so peaceful
+```
+
+The original author of this program is unknown. It was modified and reworked by Jim Bailey, Peggy Ewing, and Dave Ahl at DEC.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=128)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=143)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/71_Poker/README.md
+++ b/71_Poker/README.md
@@ -1,7 +1,16 @@
 ### Poker
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=129
+You and the computer are opponents in this game of draw poker. At the start of the game, each player is given $200. The game ends when either player runs out of money, although if you go broke the computer will offer to buy back your wristwatch or diamond tie tack.
+
+The computer opens the betting before the draw; you open the betting after the draw. If you don’t have a hand that’s worth anything and you want to fold, bet 0. Prior to the draw, to check the draw, you may bet .5. Of course, if the computer has made a bet, you must match it in order to draw or, if you have a good hand, you may raise the bet at any time.
+
+The author is A. Christopher Hall of Trinity College, Hartford, Connecticut.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=129)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=144)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/72_Queen/README.md
+++ b/72_Queen/README.md
@@ -1,7 +1,16 @@
 ### Queen
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=133
+This game is based on the permissible moves of the chess queen — i.e., along any vertical, horizontal, or diagonal. In this game, the queen can only move to the left, down, and diagonally down to the left.
+
+The object of the game is to place the queen (one only) in the lower left-hand square (no. 158), by alternating moves between you and the computer. The one to place the queen there wins.
+
+You go first and place the queen in any one of the squares on the top row or the right-hand column. That is your first move. The computer is beatable, but it takes some figuring. See if you can devise a winning strategy.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=133)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=148)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/73_Reverse/README.md
+++ b/73_Reverse/README.md
@@ -1,7 +1,31 @@
 ### Reverse
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=135
+The game of REVERSE requires you to arrange a list of numbers in numerical order from left to right. To move, you tell the computer how many numbers (counting from the left) to reverse. For example, if the current list is:
+```
+    2 3 4 5 1 6 7 8 9
+```
+
+and you reverse 4, the result will be:
+```
+    5 4 3 2 1 6 7 8 9
+```
+Now if you reverse 5, you win!
+
+There are many ways to beat the game, but approaches tend to be either algorithmic or heuristic. The game thus offers the player a chance to play with these concepts in a practical (rather than theoretical) context.
+
+An algorithmic approach guarantees a solution in a predictable number of moves, given the number of items in the list. For example, one method guarantees a solution in 2N - 3 moves when teh list contains N numbers. The essence of an algorithmic approach is that you know in advance what your next move will be. Once could easily program a computer to do this.
+
+A heuristic approach takes advantage of “partial orderings” in the list at any moment. Using this type of approach, your next move is dependent on the way the list currently appears. This way of solving the problem does not guarantee a solution in a predictable number of moves, but if you are lucky and clever, you may come out ahead of the algorithmic solutions. One could not so easily program this method.
+
+In practice, many players adopt a “mixed” strategy, with both algorithmic and heuristic features. Is this better than either “pure” strategy?
+
+The program was created by Peter Sessions of People’s Computer Company and the notes above adapted from his original write-up.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=135)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=150)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/74_Rock_Scissors_Paper/README.md
+++ b/74_Rock_Scissors_Paper/README.md
@@ -1,7 +1,21 @@
 ### Rock, Scissors, Paper
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=137
+Remember the game of rock-scissors-paper. You and your opponent make a motion three times with your fists and then either show:
+- a flat hand (paper)
+- fist (rock)
+- two fingers (scissors)
+
+Depending upon what is shown, the game is a tie (both show the same) or one person wins. Paper wraps up rock, so it wins. Scissors cut paper, so they win. And rock breaks scissors, so it wins.
+
+In this computerized version of rock-scissors-paper, you can play up to ten games vs. the computer.
+
+Charles Lund wrote this game while at the American School in The Hague, Netherlands.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=137)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=152)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/75_Roulette/README.md
+++ b/75_Roulette/README.md
@@ -1,7 +1,16 @@
 ### Roulette
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=138
+This game simulates an American Roulette wheel; “American” because it has 38 number compartments (1 to 36, 0 and 00). The European wheel has 37 numbers (1 to 36 and 0). The Bahamas, Puerto Rico, and South American countries are slowly switching to the American wheel because it gives the house a bigger percentage. Odd and even numbers alternate around the wheel, as do red and black. The layout of the wheel insures a highly random number pattern. In fact, roulette wheels are sometimes used to generate tables of random numbers.
+
+In this game, you may bet from $5 to $500 and you may bet on red or black, odd or even, first or second 18 numbers, a column, or single number. You may place any number of bets on each spin of the wheel.
+
+There is no long-range winning strategy for playing roulette. However, a good strategy is that of “doubling.” First spin, bet $1 on an even/odds bet (odd, even, red, or black). If you lose, double your bet again to $2. If you lose again, double to $4. Continue to double until you win (i.e, you break even on a losing sequence). As soon as you win, bet $1 again, and after every win, bet $1. Do not ever bet more than $1 unless you are recuperating losses by doubling. Do not ever bet anything but the even odds bets. Good luck!
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=138)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=153)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/76_Russian_Roulette/README.md
+++ b/76_Russian_Roulette/README.md
@@ -1,7 +1,14 @@
 ### Russian Roulette
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=141
+In this game, you are given by the computer a revolver loaded with one bullet and five empty chambers. You spin the chamber and pull the trigger by inputting a “1,” or, if you want to quit, input a “2.” You win if you play ten times and are still alive.
+
+Tom Adametx wrote this program while a student at Curtis Jr. High School in Sudbury, Massachusetts.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=141)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=153)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/77_Salvo/README.md
+++ b/77_Salvo/README.md
@@ -1,7 +1,25 @@
 ### Salvo
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=142
+The rules are _not_ explained by the program, so read carefully this description by Larry Siegel, the program author.
+
+SALVO is played on a 10x10 grid or board using an x,y coordinate system. The player has 4 ships:
+- battleship (5 squares)
+- cruiser (3 squares)
+- two destroyers (2 squares each)
+
+The ships may be placed horizontally, vertically, or diagonally and must not overlap. The ships do not move during the game.
+
+As long as any square of a battleship still survives, the player is allowed three shots, for a cruiser 2 shots, and for each destroyer 1 shot. Thus, at the beginning of the game the player has 3+2+1+1=7 shots. The players enters all of his shots and the computer tells what was hit. A shot is entered by its grid coordinates, x,y. The winner is the one who sinks all of the opponents ships.
+
+Important note: Your ships are located and the computer’s ships are located on 2 _separate_ 10x10 boards.
+
+Author of the program is Lawrence Siegel of Shaker Heights, Ohio.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=142)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=157)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/78_Sine_Wave/README.md
+++ b/78_Sine_Wave/README.md
@@ -1,7 +1,12 @@
 ### Sine Wave
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=146
+Did you ever go to a computer show and see a bunch of CRT terminals just sitting there waiting forlornly for someone to give a demo on them. It was one of those moments when I was at DEC that I decided there should be a little bit of background activity. And why not plot with words instead of the usual X’s? Thus SINE WAVE was born and lives on in dozens on different versions. At least those CRTs don’t look so lifeless anymore.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=146)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=161)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/79_Slalom/README.md
+++ b/79_Slalom/README.md
@@ -1,7 +1,16 @@
 ### Slalom
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=147
+This game simulates a slalom run down a course with one to 25 gates. The user picks the number of gates and has some control over his speed down the course.
+
+If you’re not a skier, here’s your golden opportunity to try it with minimal risk. If you are a skier, here’s something to do while your leg is in a cast.
+
+SLALOM was written by J. Panek while a student at Dartmouth College.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=147)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=162)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/80_Slots/README.md
+++ b/80_Slots/README.md
@@ -1,7 +1,18 @@
 ### Slots
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=149
+The slot machine or one-arm bandit is a mechanical device that will absorb coins just about as fast as you can feed it. After inserting a coin, you pull a handle that sets three independent reels spinning. If the reels stop with certain symbols appearing in the pay line, you get a certain payoff. The original slot machine, called the Liberty Bell, was invented in 1895 by Charles Fey in San Francisco. Fey refused to sell or lease the manufacturing rights, so H.S. Mills in Chicago built a similar, but much improved machine called the Operators Bell. This has survived nearly unchanged to today.
+
+On the Operators Bell and other standard slot machines, there are 20 symbols on each wheel but they are not distributed evenly among the objects (cherries, bar, apples, etc.). Of the 8,000 passible combinations, the expected payoff (to the player) is 7,049 or $89.11 for every $100.00 put in, one of the lowest expected payoffs in all casino games.
+
+In the program here, the payoff is considerably more liberal; indeed it appears to favor the player by 11% — i.e., an expected payoff of $111 for each $100 bet.
+
+The program was originally written by Fred Mirabella and Bob Harper.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=149)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=164)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/81_Splat/README.md
+++ b/81_Splat/README.md
@@ -1,7 +1,16 @@
 ### Splat
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=151
+SPLAT simulates a parachute jump in which you try to open your parachute at the last possible moment without going splat! You may select your own terminal velocity or let the computer do it for you. You many also select the acceleration due to gravity or, again, let the computer do it in which case you might wind up on any of eight planets (out to Neptune), the moon, or the sun.
+
+The computer then tells you the height you’re jumping from and asks for the seconds of free fall. It then divides your free fall time into eight intervals and gives you progress reports on your way down. The computer also keeps track of all prior jumps in the array A and lets you know how you compared with previous successful jumps. If you want to recall information from previous runs, then you should store array A in a disk or take file and read it before each run.
+
+John Yegge created this program while at the Oak Ridge Associated Universities.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=151)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=166)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/82_Stars/README.md
+++ b/82_Stars/README.md
@@ -1,7 +1,16 @@
 ### Stars
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=153
+In this game, the computer selects a random number from 1 to 100 (or any value you set). You try to guess the number and the computer gives you clues to tell you how close you’re getting. One star (\*) means you’re far away from the number; seven stars (\*\*\*\*\*\*\*) means you’re really close. You get 7 guesses.
+
+On the surface this game is similar to GUESS; however, the guessing strategy is quite different. See if you can come up with one or more approaches to finding the mystery number.
+
+Bob Albrecht of People’s Computer Company created this game.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=153)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=166)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/83_Stock_Market/README.md
+++ b/83_Stock_Market/README.md
@@ -1,7 +1,16 @@
 ### Stock Market
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=154
+This program “plays” the stock market. You will be given $10,000 and may buy or sell stocks. Stock prices and trends are generated randomly; therefore, this model does not represent exactly what happens on the exchange. (Depending upon your point of view, you may feel this is quite a good representation!)
+
+Every trading day, a table of stocks, their prices, and number of shares in your portfolio is printed. Following this, the initials of each stock are printed followed by a question mark. You indicate your transaction in number of shares — a positive number to buy, negative to sell, or 0 to do no trading. A brokerage fee of 1% is charges on all transactions (a bargain!). Note: Even if the value of a stock drops to zero, it may rebound again — then again, it may not.
+
+This program was created by D. Pessel, L. Braun, and C. Losik of the Huntington Computer Project at SUNY, Stony Brook, N.Y.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=154)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=166)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/84_Super_Star_Trek/README.md
+++ b/84_Super_Star_Trek/README.md
@@ -1,7 +1,98 @@
 ### Super Star Trek
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=157
+#### Brief History
+Many versions of Star Trek have been kicking around various college campuses since the late sixties. I recall playing one at Carnegie-Mellon Univ. in 1967 or 68, and a very different one at Berkeley. However, these were a far cry from the one written by Mike Mayfield of Centerline Engineering and/or Custom Data. This was written for an HP2000C and completed in October 1972. It became the “standard” Star Trek in February 1973 when it was put in the HP contributed program library and onto a number of HP Data Center machines.
+
+In the summer of 1973, I converted the HP version to BASIC-PLUS for DEC’s RSTS-11 compiler and added a few bits and pieces while I was at it. Mary Cole at DEC contributed enormously to this task too. Later that year I published it under the name SPACWE (Space War — in retrospect, an incorrect name) in my book _101 Basic Computer Games_.It is difficult today to find an interactive computer installation that does not have one of these versions of Star Trek available.
+
+#### Quadrant Nomenclature
+Recently, certain critics have professed confusion as to the origin on the “quadrant” nomenclature used on all standard CG (Cartesian Galactic) maps. Naturally, for anyone with the remotest knowledge of history, no explanation is necessary; however, the following synopsis should suffice for the critics:
+
+As everybody schoolboy knows, most of the intelligent civilizations in the Milky Way had originated galactic designations of their own choosing well before the Third Magellanic Conference, at which the so-called “2⁶ Agreement” was reached. In that historic document, the participant cultures agreed, in all two-dimensional representations of the galaxy, to specify 64 major subdivisions, ordered as an 8 x 8 matrix. This was partially in deference to the Earth culture (which had done much in the initial organization of the Federation), whose century-old galactic maps had landmarks divided into four “quadrants,” designated by ancient “Roman Numerals” (the origin of which has been lost).
+
+To this day, the official logs of starships originating on near-Earth starbases still refer to the major galactic areas as “quadrants.”
+
+The relation between the Historical and Standard nomenclatures is shown in the simplified CG map below.
+
+|   | 1            | 2  | 3   | 4  | 5          | 6  | 7   | 8  |
+|---|--------------|----|-----|----|------------|----|-----|----|
+| 1 |    ANTARES   |    |     |    |   SIRIUS   |    |     |    |
+|   | I            | II | III | IV | I          |    | III | IV |
+| 2 |     RIGEL    |    |     |    |    DENEB   |    |     |    |
+|   | I            | II | III | IV | I          | II | III | IV |
+| 3 |    PROCYON   |    |     |    |   CAPELLA  |    |     |    |
+|   | I            | II | III | IV | I          | II | III | IV |
+| 4 | VEGA         |    |     |    | BETELGUESE |    |     |    |
+|   | I            | II | III | IV | I          | II | III | IV |
+| 5 |    CANOPUS   |    |     |    |  ALDEBARA  |    |     |    |
+|   | I            | II | III | IV | I          | II | III | IV |
+| 6 |    ALTAIR    |    |     |    |   REGULUS  |    |     |    |
+|   | I            | II | III | IV | I          | II | III | IV |
+| 7 | SAGITTARIOUS |    |     |    |  ARCTURUS  |    |     |    |
+|   | I            | II | III | IV | I          | II | III | IV |
+| 8 |    POLLUX    |    |     |    |    SPICA   |    |     |    |
+|   | I            | II | III | IV | I          | II | III | IV |
+
+#### Super Star Trek† Rules and Notes
+1. OBJECTIVE: You are Captain of the starship “Enterprise”† with a mission to seek and destroy a fleet of Klingon† warships (usually about 17) which are menacing the United Federation of Planets.† You have a specified number of stardates in which to complete your mission. You also have two or three Federation Starbases† for resupplying your ship.
+
+2. You will be assigned a starting position somewhere in the galaxy. The galaxy is divided into an 8 x 8 quadrant grid. The astronomical name of a quadrant is called out upon entry into a new region. (See “Quadrant Nomenclature.”) Each quadrant is further divided into an 8 x 8 section grid.
+
+3. On a section diagram, the following symbols are used:
+    - `<*>` Enterprise
+    - `†††` Klingon
+    - `>!<` Starbase
+    - `*`   Star
+
+4. You have eight commands available to you (A detailed description of each command is given in the program instructions.)
+    - `NAV` Navigate the Starship by setting course and warp engine speed.
+    - `SRS` Short-range sensor scan (one quadrant)
+    - `LRS` Long-range sensor scan (9 quadrants)
+    - `PHA` Phaser† control (energy gun)
+    - `TOR` Photon torpedo control
+    - `SHE` Shield control (protects against phaser fire)
+    - `DAM` Damage and state-of-repair report
+    - `COM` Call library computer
+
+5. Library computer options are as follows (more complete descriptions are in program instructions):
+    - `0` Cumulative galactic report
+    - `1` Status report
+    - `2` Photon torpedo course data
+    - `3` Starbase navigation data
+    - `4` Direction/distance calculator
+    - `5` Quadrant nomenclature map
+
+6. Certain reports on the ship’s status are made by officers of the Enterprise who appears on the original TV Show—Spock,† Scott,† Uhura,† Chekov,† etc.
+
+7. Klingons are non-stationary within their quadrants. If you try to maneuver on them, they will move and fire on you.
+
+8. Firing and damage notes:
+    - Phaser fire diminishes with increased distance between combatants.
+    - If a Klingon zaps you hard enough (relative to your shield strength) he will generally cause damage to some part of your ship with an appropriate “Damage Control” report resulting.
+    - If you don’t zap a Klingon hard enough (relative to his shield strength) you won’t damage him at all. Your sensors will tell the story.
+    - Damage control will let you know when out-of-commission devices have been completely repaired.
+
+9. Your engines will automatically shit down if you should attempt to leave the galaxy, or if you should try to maneuver through a star, or Starbase, or—heaven help you—a Klingon warship.
+
+10. In a pinch, or if you should miscalculate slightly, some shield control energy will be automatically diverted to warp engine control (if your shield are operational!).
+
+11. While you’re docked at a Starbase, a team of technicians can repair your ship (if you’re willing for them to spend the time required—and the repairmen _always_ underestimate…)
+
+12. If, to same maneuvering time toward the end of the game, you should cold-bloodedly destroy a Starbase, you get a nasty note from Starfleet Command. If you destroy your _last_ Starbase, you lose the game! (For those who think this is too a harsh penalty, delete line 5360-5390, and you’ll just get a “you dumdum!”-type message on all future status reports.)
+
+13. End game logic has been “cleaned up” in several spots, and it is possible to get a new command after successfully completing your mission (or, after resigning your old one).
+
+14. For those of you with certain types of CRT/keyboards setups (e.g. Westinghouse 1600), a “bell” character is inserted at appropriate spots to cause the following items to flash on and off on the screen:
+    - The Phrase “\*RED\*” (as in Condition: Red)
+    - The character representing your present quadrant in the cumulative galactic record printout.
+
+15. This version of Star Trek was created for a Data General Nova 800 system with 32K or core. So that it would fit, the instructions are separated from the main program via a CHAIN. For conversion to DEC BASIC-PLUS, Statement 160 (Randomize) should be moved after the return from the chained instructions, say to Statement 245. For Altair BASIC, Randomize and the chain instructions should be eliminated.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=157)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=166)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html
@@ -11,4 +102,3 @@ instructions.txt
 
 #### External Links
  - Super Star Trek in C++ : https://www.codeproject.com/Articles/28399/The-Object-Oriented-Text-Star-Trek-Game-in-C
-

--- a/85_Synonym/README.md
+++ b/85_Synonym/README.md
@@ -1,7 +1,20 @@
 ### Synonym
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=164
+A synonym of a word is another word (in the English language) which has the same, or very nearly the same, meaning. This program tests your knowledge of synonyms of a few common words.
+
+The computer chooses a word and asks you for a synonym. The computer then tells you whether you’re right or wrong. If you can’t think of a synonym, type “HELP” which causes a synonym to be printed.
+
+You may put in words of your choice in the data statements. The number following DATA in Statement 500 is the total number of data statements. In each data statement, the first number is the number of words in that statement.
+
+Can you think of a way to make this into a more general kind of CAI program for any subject?
+
+Walt Koetke of Lexington High School, Massachusetts created this program.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=164)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=179)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/86_Target/README.md
+++ b/86_Target/README.md
@@ -1,7 +1,16 @@
 ### Target
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=165
+In this program, you are firing a weapon from a spaceship in 3-dimensional space. Your ship, the Starship Enterprise, is located at the origin (0,0,0) of a set of x,y,z coordinates. You will be told the approximate location of the target in 3-dimensional rectangular coordinates, the approximate angular deviation from the x and z axes in both radians and degrees, and the approximate distance to the target.
+
+Given this information, you then proceed to shoot at the target. A shot within 20 kilometers of the target destroys it. After each shot, you are given information as to the position of the explosion of your shot and a somewhat improved estimate of the location of the target. Fortunately, this is just practice and the target doesn’t shoot back. After you have attained proficiency, you ought to be able to destroy a target in 3 or 4 shots. However, attaining proficiency might take a while!
+
+The author is H. David Crockett of Fort Worth, Texas.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=165)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=180)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/87_3-D_Plot/README.md
+++ b/87_3-D_Plot/README.md
@@ -1,7 +1,16 @@
 ### 3-D Plot
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=167
+3-D PLOT will plot the family of curves of any function. The function Z is plotted as “rising” out of the x-y plane with x and y inside a circle of radius 30. The resultant plot looks almost 3-dimensional.
+
+You set the function you want plotted in line 5. As with any mathematical plot, some functions come out “prettier” than others.
+
+The author of this amazingly clever program is Mark Bramhall of DEC.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=167)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=182)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/88_3-D_Tic-Tac-Toe/README.md
+++ b/88_3-D_Tic-Tac-Toe/README.md
@@ -1,7 +1,17 @@
 ### 3-D Tic-Tac-Toe
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=168
+3-D TIC-TAC-TOE is a game of tic-tac-toe in a 4x4x4 cube. You must get 4 markers in a row or diagonal along any 3-dimensional plane in order to win.
+
+Each move is indicated by a 3-digit number (digits not separated by commas), with each digit between 1 and 4 inclusive. The digits indicate the level, column, and row, respectively, of the move. You can win if you play correctly; although, it is considerably more difficult than standard, two-dimensional 3x3 tic-tac-toe.
+
+This version of 3-D TIC-TAC-TOE is from Dartmouth College.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=168)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=183)
+
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/89_Tic-Tac-Toe/README.md
+++ b/89_Tic-Tac-Toe/README.md
@@ -1,7 +1,25 @@
 ### Tic-Tac-Toe
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=171
+The game of tic-tac-toe hardly needs any introduction. In this one, you play versus the computer. Moves are entered by number:
+```
+1   2   3
+
+4   5   6
+
+7   8   9
+```
+
+If you make any bad moves, the computer will win; if the computer makes a bad move, you can win; otherwise, the game ends in a tie.
+
+A second version of the game is included which prints out the board after each move. This is ideally suited to a CRT terminal, particularly if you modify it to not print out a new board after each move, but rather use the cursor to make the move.
+
+The first program was written by Tom Koos while a student researcher at the Oregon Museum of Science and Industry; it was extensively modified by Steve North of Creative Computing. The author of the second game is Curt Flick of Akron, Ohio.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=171)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=186)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/90_Tower/README.md
+++ b/90_Tower/README.md
@@ -1,7 +1,20 @@
 ### Tower
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=173
+This is a simulation of a game of logic that originated in the middle East. It is sometimes called Pharaoh's Needles, but its most common name is the Towers of Hanoi.
+
+Legend has it that a secret society of monks live beneath the city of Hanoi. They possess three large towers or needles on which different size gold disks may be placed. Moving one at a time and never placing a large on a smaller disk, the monks endeavor to move the tower of disks from the left needle to the right needle. Legend says when they have finished moving this 64-disk tower, the world will end. How many moves will they have to make to accomplish this? If they can move 1 disk per minute and work 24 hours per day, how many years will it take?
+
+In the computer puzzle you are faced with three upright needles. On the leftmost needle are placed from two to seven graduated disks, the largest being on bottom and smallest on top. Your object is to move the entire stack of disks to the rightmost needle. However, you many only move one disk at a time and you may never place a larger disk on top of a smaller one.
+
+In this computer game, the disks are referred to by their size — i.e., the smallest is 3, next 5, 7, 9, 11, 13, and 15. If you play with fewer than 7 disks always use the largest, i.e. with 2 disks you would use nos. 13 and 15. The program instructions are self-explanatory. Good luck!
+
+Charles Lund wrote this program while at the American School in the Hague, Netherlands.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=173)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=188)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/91_Train/README.md
+++ b/91_Train/README.md
@@ -1,7 +1,16 @@
 ### Train
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=175
+TRAIN is a program which uses the computer to generate problems with random initial conditions to teach about the time-speed-distance relationship (distance = rate x time). You then input your answer and the computer verifies your response.
+
+TRAIN is merely an example of a student-generated problem. Maximum fun (and benefit) comes more from _writing_ programs like this as opposed to solving the specific problem posed. Exchange your program with others—you solve their problem and let them solve yours.
+
+TRAIN was originally written in FOCAL by one student for use by others in his class. It was submitted to us by Walt Koetke, Lexington High School, Lexington, Mass.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=175)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=190)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/92_Trap/README.md
+++ b/92_Trap/README.md
@@ -1,7 +1,19 @@
 ### Trap
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=176
+This is another in the family of “guess the mystery number” games. In TRAP the computer selects a random number between 1 and 100 (or other limit set). Your object is to find the number. On each guess, you enter 2 numbers trying to trap the mystery number between your two trap numbers. The computer will tell you if you have trapped the number.
+
+To win the game, you must guess the mystery number by entering it as the same value for both of your trap numbers. You get 6 guesses (this should be changed if you change the guessing limit).
+
+After you have played GUESS, STARS, and TRAP, compare the guessing strategy you have found best for each game. Do you notice any similarities? What are the differences? Can you write a new guessing game with still another approach?
+
+TRAP was suggested by a 10-year-old when he was playing GUESS. It was originally programmed by Steve Ullman and extensively modified into its final form by Bob Albrecht of People’s Computer Co.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=176)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=191)
+
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/93_23_Matches/README.md
+++ b/93_23_Matches/README.md
@@ -1,7 +1,18 @@
 ### 23 Matches
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=177
+In the game of twenty-three matches, you start with 23 matches lying on a table. On each turn, you may take 1, 2, or 3 matches. You alternate moves with the computer and the one who has to take the last match loses.
+
+The easiest way to devise a winning strategy is to start at the end of the game. Since your wish to leave the last match to your opponent, you would like to have either 4, 3, or 2 on your last turn you so can take away 3, 2, or 1 and leave 1. Consequently, you would like to leave your opponent with 5 on his next to last turn so, no matter what his move, you are left with 4, 3, or 2. Work this backwards to the beginning and you’ll find the game can effectively be won on the first move. Fortunately, the computer gives you the first move, so if you play wisely, you can win.
+
+After you’ve mastered 23 Matches, move on to BATNUM and then to NUM.
+
+This version of 23 Matches was originally written by Bob Albrecht of People’s Computer Company.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=177)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=192)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/94_War/README.md
+++ b/94_War/README.md
@@ -1,7 +1,14 @@
 ### War
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=178
+This program plays the card game of War. In War, the card deck is shuffled, then two cards are dealt, one to each player. Players compare cards and the higher card (numerically) wins. In case of a tie, no one wins. The game ends when you have gone through the whole deck (52 cards, 26 games) or when you decide to quit.
+
+The computer gives cards by suit and number, for example, S-7 is the 7 of spades.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=178)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=193)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/95_Weekday/README.md
+++ b/95_Weekday/README.md
@@ -1,7 +1,16 @@
 ### Weekday
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=179
+This program gives facts about your date of birth (or some other day of interest). It is not prepared to give information on people born before the use of the current type of calendar, i.e. year 1582.
+
+You merely enter today’s date in the form—month, day, year and your date of birth in the same form. The computer then tells you the day of the week of your birth date, your age, and how much time you have spent sleeping, eating, working, and relaxing.
+
+This program was adapted from a GE timesharing program by Tom Kloos at the Oregon Museum of Science and Industry.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=179)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=194)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html

--- a/96_Word/README.md
+++ b/96_Word/README.md
@@ -1,7 +1,16 @@
 ### Word
 
-As published in Basic Computer Games (1978)
-https://www.atariarchives.org/basicgames/showpage.php?page=181
+WORD is a combination of HANGMAN and BAGELS. In this game, the player must guess a word with clues as to a letter position furnished by the computer. However, instead of guessing one letter at a time, in WORD you guess an entire word (or group of 5 letters, such as ABCDE). The computer will tell you if any letters that you have guessed are in the mystery word and if any of them are in the correct position. Armed with these clues, you go on guessing until you get the word or, if you can’t get it, input a “?” and the computer will tell you the mystery word.
+
+You may change the words in Data Statements, but they must be 5-letter words.
+
+The author of this program is Charles Reid of Lexington High School, Lexington, Massachusetts.
+
+---
+
+As published in Basic Computer Games (1978):
+- [Atari Archives](https://www.atariarchives.org/basicgames/showpage.php?page=181)
+- [Annarchive](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf#page=194)
 
 Downloaded from Vintage Basic at
 http://www.vintage-basic.net/games.html


### PR DESCRIPTION
Proposal adds game descriptions to the non-language specific game READMEs. Not sure if this has already been done elsewhere.
 
## NOTES
- Added additional archive link; links to page in full book PDF
- I wrote each game description by hand—a wonderful typing exercise— possibility of typo introduction
- Did not perform any grammatical changes
- Markdown code blocks are used for some text
- Only typos I’ve noticed as part of the book are (I did fix these)
  - 43: Hammurabi — “accessment”
  - 62:Mugwump — “truneated”
  - 79: Slalom — “a course with from to 25 gates”
- Brought over italicized words wherever I noticed them
- I used “smart//curly” quotes out of habit (`“”‘’ vs ""''`)—not sure if this is an issue
- Individual paragraphs do not contain carriage returns (as a code comment typically would)
- Left out specific line number references
- Used lists where I felt it made sense, instead of keeping text in paragraph-line
- 68: Orbit includes some homemade text-graphics instead of images; does not include the practice off-line problem.
- 69: Pizza has “Send us your modifications!”
- 70: Poetry has “Send us the output.”
- 84: Star Trek: I left in the (†) mark usage.

## Personal Notes
I really enjoyed reading each game (and enjoyed writing most of them)—there’s so many games I’ve never heard of! And it was fun to see games I grew up playing as well.

These were played by literally printing to paper‽ 
> If you elect to see all the pictures, this program has the ability of consuming well over six feet of terminal paper per run. We can only suggest recycling the paper by using the other side. (16:Bug)

> “This program fills an 8.5x11 piece of paper with diamonds (plotted on a hard-copy terminal, of course) (32:Diamond)

I’ve never made the connection that “print” statements were literal—print to _paper_ statements.

I find it interesting how each author is credited to a city and state.

I find it interesting how many of the games are war-oriented, with troops and command—though thinking about it, that’s just about every game.

I find it interesting to see many game descriptions talk about finding a winning strategy.

It’s really cool to see some authors were in middle school and high school.

I’m curious to learn more about the implementations of “computer learning” through these games.
- 4: Awari
- 35: Even Wins: “If you plot the learning curve of this program, it closely resembles classical human learning curves from psychological experiments.”
- 46: Hexapawn

45: Hello
> In this particular program, the computer dispenses advice on various problems such as sex. health, money, or job.

Made me laugh the most.

63: Name
> The sorting algorithm used is highly inefficient — as any reader of _Creative Computing_ will recognize, this is the worst possible sort for speed But the program is good fun and that’s what counts here.

- 71: Rock-scissors-paper: this ordering brought out an internal scream. [Rock-paper-scissors](https://en.wikipedia.org/wiki/Rock_paper_scissors)!

- 75: Roulette:
> In fact, roulette wheels are sometimes used to generate tables of random numbers.

Huh, weird fact. Also, there’s no mention of an author—not even an unknown author, just no mention.

I don’t think there’s a single “she” or “her” used—all “his” and “him.” Just bringing it up.

I lied earlier, 79: Slalom:
> If you’re not a skier, here’s your golden opportunity to try it with minimal risk. If you are a skier, here’s something to do while your leg is in a cast.

Made me laugh to most.

80: Slots:
> The slot machine or one-arm bandit is a mechanical device that will absorb coins just about as fast as you can feed it.
Also funny.

Note for later: 90 has two folders.