### PR TITLE
added non-source code exclusions to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,18 @@
+.local/
+.vscode/
+.gradle/
+node_modules/
+buildJvm/
+
+build.gradle
+
+.classpath
+.project
+.settings
+.metadata
+*.iml
+*.ipr
+
 *.class
 */.vs
 *.suo
@@ -12,6 +27,7 @@ obj/
 out/
 
 *.py[co]
+
 Pipfile
 
 .DS_Store


### PR DESCRIPTION
This probably needs to be a more comprehensive .gitignore with the variety of language source code coming in. I added exclusions for node, gradle, etc and an exclusion for a .local directory in case developers want to have local files not shared with the larger project.

