### PR TITLE
Fixes to the Python version of Hamurabi

### DIFF
--- a/43_Hammurabi/python/hamurabi.py
+++ b/43_Hammurabi/python/hamurabi.py
@@ -154,7 +154,8 @@ while Z < 11:  # line 270. main loop. while the year is less than 11
     if int(C / 2) == C / 2:  # even number. 50/50 chance
         # REM *** RATS ARE RUNNING WILD!!
         E = int(S / C)  # calc losses due to rats, based on previous random number
-        S = S - E + H  # deduct losses from stores
+
+    S = S - E + H  # deduct losses from stores
 
     C = gen_random()
     # REM *** LET'S HAVE SOME BABIES

--- a/43_Hammurabi/python/hamurabi.py
+++ b/43_Hammurabi/python/hamurabi.py
@@ -137,7 +137,7 @@ while Z < 11:  # line 270. main loop. while the year is less than 11
                 # REM *** ENOUGH GRAIN FOR SEED?
                 bad_input_710(S)
                 D = -99
-            elif D >= 10 * P:
+            elif D > 10 * P:
                 # REM *** ENOUGH PEOPLE TO TEND THE CROPS?
                 print("BUT YOU HAVE ONLY", P, "PEOPLE TO TEND THE FIELDS!  NOW THEN,")
                 D = -99


### PR DESCRIPTION
I tried playing the python version and discovered a bug that makes it unplayable.
Unless the rats eat some of the food (50% chance per turn),
your harvest wasn't added to the total.

This was due to an indentation error, so the calculation for total bushels was 
included in the rat condition.

The other commit checks the amount of people available to harvest the fields.
In the rules, each person is supposed to be able to harvest 10 acres, but the
code as written doesn't like you harvest that maximum.

However, I think that bug was in the original code.