### PR TITLE
Apply black to the 00_Utilities/markdown_todo.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ obj/
 out/
 
 *.py[co]
-
+.python-version
 Pipfile
 
 .DS_Store

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,34 @@
+# pre-commit run --all-files
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.1.0
+    hooks:
+    -   id: check-ast
+    -   id: check-byte-order-marker
+    -   id: check-case-conflict
+    -   id: check-docstring-first
+    -   id: check-executables-have-shebangs
+    -   id: check-json
+    -   id: check-yaml
+    -   id: debug-statements
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+    -   id: mixed-line-ending
+-   repo: https://github.com/pre-commit/mirrors-isort
+    rev: v5.10.1
+    hooks:
+    -   id: isort
+-   repo: https://github.com/psf/black
+    rev: 22.1.0
+    hooks:
+    -   id: black
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v2.31.0
+    hooks:
+    -   id: pyupgrade
+        args: [--py37-plus]
+-   repo: https://github.com/asottile/blacken-docs
+    rev: v1.12.1
+    hooks:
+    -   id: blacken-docs
+        additional_dependencies: [black==20.8b1]

--- a/00_Utilities/markdown_todo.py
+++ b/00_Utilities/markdown_todo.py
@@ -1,26 +1,40 @@
 import os
 
-
 lang_pos = {
-    "csharp": 1, "java": 2, "javascript": 3,
-    "pascal": 4, "perl": 5, "python": 6, "ruby": 7, "vbnet": 8
+    "csharp": 1,
+    "java": 2,
+    "javascript": 3,
+    "pascal": 4,
+    "perl": 5,
+    "python": 6,
+    "ruby": 7,
+    "vbnet": 8,
 }
 
 write_string = "# TODO list \n game | csharp | java | javascript | pascal | perl | python | ruby | vbnet \n --- | --- | --- | --- | --- | --- | --- | --- | ---  \n"
 # Set the directory you want to start from
-rootDir = '..'
+rootDir = ".."
 
 strings_done = []
 
-checklist = ["game", "csharp", "java", "javascript",
-             "pascal", "perl", "python", "ruby", "vbnet"]
+checklist = [
+    "game",
+    "csharp",
+    "java",
+    "javascript",
+    "pascal",
+    "perl",
+    "python",
+    "ruby",
+    "vbnet",
+]
 
 prev_game = ""
 
 for dirName, subdirList, fileList in os.walk(rootDir):
     split_dir = dirName.split(os.path.sep)
 
-    if len(split_dir) == 2 and not split_dir[1] in ['.git', '00_Utilities']:
+    if len(split_dir) == 2 and not split_dir[1] in [".git", "00_Utilities"]:
         if prev_game == "":
             prev_game = split_dir[1]
             checklist[0] = split_dir[1]
@@ -28,11 +42,20 @@ for dirName, subdirList, fileList in os.walk(rootDir):
         if prev_game != split_dir[1]:
             # it's a new dir
             strings_done.append(checklist)
-            checklist = [split_dir[1], "csharp", "java", "javascript",
-                         "pascal", "perl", "python", "ruby", "vbnet"]
+            checklist = [
+                split_dir[1],
+                "csharp",
+                "java",
+                "javascript",
+                "pascal",
+                "perl",
+                "python",
+                "ruby",
+                "vbnet",
+            ]
             prev_game = split_dir[1]
 
-    elif len(split_dir) == 3 and split_dir[1] != '.git':
+    elif len(split_dir) == 3 and split_dir[1] != ".git":
         if split_dir[2] in lang_pos.keys():
             if len(fileList) > 1 or len(subdirList) > 0:
                 # there is more files than the readme
@@ -41,10 +64,11 @@ for dirName, subdirList, fileList in os.walk(rootDir):
                 checklist[lang_pos[split_dir[2]]] = "⬜️"
 
 
-sorted_strings = list(map(lambda l: " | ".join(l) + "\n",
-                          sorted(strings_done, key=lambda x: x[0])))
-write_string += ''.join(sorted_strings)
+sorted_strings = list(
+    map(lambda l: " | ".join(l) + "\n", sorted(strings_done, key=lambda x: x[0]))
+)
+write_string += "".join(sorted_strings)
 
 
-with open("README.md", "w", encoding='utf-8') as f:
+with open("README.md", "w", encoding="utf-8") as f:
     f.write(write_string)


### PR DESCRIPTION
Adding some tooling to write good code:
* Black is the standard code formatter for Python: https://pypi.org/project/black/
* isort further reduces the diff size: https://pypi.org/project/isort/
* pre-commit helps contributors to keep the commits clean: https://pypi.org/project/pre-commit/
* pyupgrade - make use of new Python language features; drop old style

I didn't run black / pre-commit over all files as this is a massive diff with tiny changes. That would make it harder to review this one. I suggest to run `pre-commit run --all` after merging this PR (with no manual changes, just the autoformatter)