### PR TITLE
Add "nice" terminal style stylesheet for javascript html

### DIFF
--- a/00_Utilities/javascript/style_terminal.css
+++ b/00_Utilities/javascript/style_terminal.css
@@ -1,0 +1,200 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+:root {
+  --background: rgb(1, 24, 1);
+  --text: rgb(51, 251, 51);
+  --input: yellow;
+}
+
+html {
+  font-size: 16px;
+}
+
+body {
+  background-color: var(--background);
+  color: var(--text);
+  font: 600 1rem/1.3 Consolas, Andale Mono, monospace;
+  padding: 3rem;
+}
+
+/* Adapted from source: http://aleclownes.com/2017/02/01/crt-display.html */
+@keyframes flicker {
+  0% {
+    opacity: 0.27861;
+  }
+  5% {
+    opacity: 0.34769;
+  }
+  10% {
+    opacity: 0.23604;
+  }
+  15% {
+    opacity: 0.90626;
+  }
+  20% {
+    opacity: 0.18128;
+  }
+  25% {
+    opacity: 0.83891;
+  }
+  30% {
+    opacity: 0.65583;
+  }
+  35% {
+    opacity: 0.67807;
+  }
+  40% {
+    opacity: 0.26559;
+  }
+  45% {
+    opacity: 0.84693;
+  }
+  50% {
+    opacity: 0.96019;
+  }
+  55% {
+    opacity: 0.08594;
+  }
+  60% {
+    opacity: 0.20313;
+  }
+  65% {
+    opacity: 0.71988;
+  }
+  70% {
+    opacity: 0.53455;
+  }
+  75% {
+    opacity: 0.37288;
+  }
+  80% {
+    opacity: 0.71428;
+  }
+  85% {
+    opacity: 0.70419;
+  }
+  90% {
+    opacity: 0.7003;
+  }
+  95% {
+    opacity: 0.36108;
+  }
+  100% {
+    opacity: 0.24387;
+  }
+}
+@keyframes textShadow {
+  0% {
+    text-shadow: 0.4389924193300864px 0 1px rgba(0,30,255,0.5), -0.4389924193300864px 0 1px rgba(255,0,80,0.3), 0 0 3px;
+  }
+  5% {
+    text-shadow: 2.7928974010788217px 0 1px rgba(0,30,255,0.5), -2.7928974010788217px 0 1px rgba(255,0,80,0.3), 0 0 3px;
+  }
+  10% {
+    text-shadow: 0.02956275843481219px 0 1px rgba(0,30,255,0.5), -0.02956275843481219px 0 1px rgba(255,0,80,0.3), 0 0 3px;
+  }
+  15% {
+    text-shadow: 0.40218538552878136px 0 1px rgba(0,30,255,0.5), -0.40218538552878136px 0 1px rgba(255,0,80,0.3), 0 0 3px;
+  }
+  20% {
+    text-shadow: 3.4794037899852017px 0 1px rgba(0,30,255,0.5), -3.4794037899852017px 0 1px rgba(255,0,80,0.3), 0 0 3px;
+  }
+  25% {
+    text-shadow: 1.6125630401149584px 0 1px rgba(0,30,255,0.5), -1.6125630401149584px 0 1px rgba(255,0,80,0.3), 0 0 3px;
+  }
+  30% {
+    text-shadow: 0.7015590085143956px 0 1px rgba(0,30,255,0.5), -0.7015590085143956px 0 1px rgba(255,0,80,0.3), 0 0 3px;
+  }
+  35% {
+    text-shadow: 3.896914047650351px 0 1px rgba(0,30,255,0.5), -3.896914047650351px 0 1px rgba(255,0,80,0.3), 0 0 3px;
+  }
+  40% {
+    text-shadow: 3.870905614848819px 0 1px rgba(0,30,255,0.5), -3.870905614848819px 0 1px rgba(255,0,80,0.3), 0 0 3px;
+  }
+  45% {
+    text-shadow: 2.231056963361899px 0 1px rgba(0,30,255,0.5), -2.231056963361899px 0 1px rgba(255,0,80,0.3), 0 0 3px;
+  }
+  50% {
+    text-shadow: 0.08084290417898504px 0 1px rgba(0,30,255,0.5), -0.08084290417898504px 0 1px rgba(255,0,80,0.3), 0 0 3px;
+  }
+  55% {
+    text-shadow: 2.3758461067427543px 0 1px rgba(0,30,255,0.5), -2.3758461067427543px 0 1px rgba(255,0,80,0.3), 0 0 3px;
+  }
+  60% {
+    text-shadow: 2.202193051050636px 0 1px rgba(0,30,255,0.5), -2.202193051050636px 0 1px rgba(255,0,80,0.3), 0 0 3px;
+  }
+  65% {
+    text-shadow: 2.8638780614874975px 0 1px rgba(0,30,255,0.5), -2.8638780614874975px 0 1px rgba(255,0,80,0.3), 0 0 3px;
+  }
+  70% {
+    text-shadow: 0.48874025155497314px 0 1px rgba(0,30,255,0.5), -0.48874025155497314px 0 1px rgba(255,0,80,0.3), 0 0 3px;
+  }
+  75% {
+    text-shadow: 1.8948491305757957px 0 1px rgba(0,30,255,0.5), -1.8948491305757957px 0 1px rgba(255,0,80,0.3), 0 0 3px;
+  }
+  80% {
+    text-shadow: 0.0833037308038857px 0 1px rgba(0,30,255,0.5), -0.0833037308038857px 0 1px rgba(255,0,80,0.3), 0 0 3px;
+  }
+  85% {
+    text-shadow: 0.09769827255241735px 0 1px rgba(0,30,255,0.5), -0.09769827255241735px 0 1px rgba(255,0,80,0.3), 0 0 3px;
+  }
+  90% {
+    text-shadow: 3.443339761481782px 0 1px rgba(0,30,255,0.5), -3.443339761481782px 0 1px rgba(255,0,80,0.3), 0 0 3px;
+  }
+  95% {
+    text-shadow: 2.1841838852799786px 0 1px rgba(0,30,255,0.5), -2.1841838852799786px 0 1px rgba(255,0,80,0.3), 0 0 3px;
+  }
+  100% {
+    text-shadow: 2.6208764473832513px 0 1px rgba(0,30,255,0.5), -2.6208764473832513px 0 1px rgba(255,0,80,0.3), 0 0 3px;
+  }
+}
+pre#output {
+  animation: textShadow 1.6s infinite;
+}
+pre#output::before {
+  content: " ";
+  display: block;
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  background: linear-gradient(rgba(18, 16, 16, 0) 50%, rgba(0, 0, 0, 0.25) 50%), linear-gradient(90deg, rgba(255, 0, 0, 0.06), rgba(0, 255, 0, 0.02), rgba(0, 0, 255, 0.06));
+  z-index: 2;
+  background-size: 100% 2px, 3px 100%;
+  pointer-events: none;
+}
+pre#output::after {
+  content: " ";
+  display: block;
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  background: rgba(18, 16, 16, 0.1);
+  opacity: 0;
+  z-index: 2;
+  pointer-events: none;
+  animation: flicker 0.15s infinite;
+}
+
+input {
+  display: inline-block;
+  position: relative;
+  caret-color: var(--input);
+  background: none;
+  border: none;
+  outline: none;
+  border-bottom: 1px solid var(--input);
+  border-style: none none dashed none;
+  color: var(--input);
+  font: 900 1rem/1.3 Consolas, Andale Mono, monospace;
+  animation: textShadow 1.6s infinite;
+  text-transform: uppercase;
+}
+

--- a/01_Acey_Ducey/javascript/aceyducey.html
+++ b/01_Acey_Ducey/javascript/aceyducey.html
@@ -1,7 +1,9 @@
 <!DOCTYPE html>
-<meta charset="utf-8" />
-<meta name="viewport" content="width=device-width" />
+<head>
 <title>ACEY DUCEY</title>
-
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
+</head>
+<body>
 <pre id="output" style="font-size: 12pt"></pre>
 <script src="aceyducey.js"></script>
+</body>

--- a/02_Amazing/javascript/amazing.html
+++ b/02_Amazing/javascript/amazing.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>AMAZING</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="amazing.js"></script>
 </body>
 </html>

--- a/03_Animal/javascript/animal.html
+++ b/03_Animal/javascript/animal.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>ANIMAL</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <!--<script src="https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js"></script>-->
 <script src="animal.js"></script>
 </body>

--- a/04_Awari/javascript/awari.html
+++ b/04_Awari/javascript/awari.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>AWARI</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="awari.js"></script>
 </body>
 </html>

--- a/05_Bagels/javascript/bagels.html
+++ b/05_Bagels/javascript/bagels.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>BAGELS</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="bagels.js"></script>
 </body>
 </html>

--- a/06_Banner/javascript/banner.html
+++ b/06_Banner/javascript/banner.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>BANNER</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="banner.js"></script>
 </body>
 </html>

--- a/07_Basketball/javascript/basketball.html
+++ b/07_Basketball/javascript/basketball.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>BASKETBALL</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="basketball.js"></script>
 </body>
 </html>

--- a/08_Batnum/javascript/batnum.html
+++ b/08_Batnum/javascript/batnum.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>BATNUM</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="batnum.js"></script>
 </body>
 </html>

--- a/09_Battle/javascript/battle.html
+++ b/09_Battle/javascript/battle.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>BATTLE</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="battle.js"></script>
 </body>
 </html>

--- a/10_Blackjack/javascript/blackjack.html
+++ b/10_Blackjack/javascript/blackjack.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>BLACKJACK</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="blackjack.js"></script>
 </body>
 </html>

--- a/11_Bombardment/javascript/bombardment.html
+++ b/11_Bombardment/javascript/bombardment.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>BOMBARDMENT</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="bombardment.js"></script>
 </body>
 </html>

--- a/12_Bombs_Away/javascript/bombsaway.html
+++ b/12_Bombs_Away/javascript/bombsaway.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>BOMBARDMENT</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="bombsaway.js"></script>
 </body>
 </html>

--- a/13_Bounce/javascript/bounce.html
+++ b/13_Bounce/javascript/bounce.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>BOUNCE</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="bounce.js"></script>
 </body>
 </html>

--- a/14_Bowling/javascript/bowling.html
+++ b/14_Bowling/javascript/bowling.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>BOWLING</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="bowling.js"></script>
 </body>
 </html>

--- a/15_Boxing/javascript/boxing.html
+++ b/15_Boxing/javascript/boxing.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>BOXING</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="boxing.js"></script>
 </body>
 </html>

--- a/16_Bug/javascript/bug.html
+++ b/16_Bug/javascript/bug.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>BUG</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="bug.js"></script>
 </body>
 </html>

--- a/17_Bullfight/javascript/bullfight.html
+++ b/17_Bullfight/javascript/bullfight.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>BULLFIGHT</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="bullfight.js"></script>
 </body>
 </html>

--- a/18_Bullseye/javascript/bullseye.html
+++ b/18_Bullseye/javascript/bullseye.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>BULLSEYE</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="bullseye.js"></script>
 </body>
 </html>

--- a/19_Bunny/javascript/bunny.html
+++ b/19_Bunny/javascript/bunny.html
@@ -1,6 +1,7 @@
 <html>
 <head>
 <title>BUNNY</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
 <pre id="output" style="font-size: 8pt;"></pre>

--- a/20_Buzzword/javascript/buzzword.html
+++ b/20_Buzzword/javascript/buzzword.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>BUZZWORD</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="buzzword.js"></script>
 </body>
 </html>

--- a/21_Calendar/javascript/calendar.html
+++ b/21_Calendar/javascript/calendar.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>CALENDAR</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 8pt;"></pre>
+<pre id="output"></pre>
 <script src="calendar.js"></script>
 </body>
 </html>

--- a/22_Change/javascript/change.html
+++ b/22_Change/javascript/change.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>CHANGE</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="change.js"></script>
 </body>
 </html>

--- a/23_Checkers/javascript/checkers.html
+++ b/23_Checkers/javascript/checkers.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>CHECKERS</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="checkers.js"></script>
 </body>
 </html>

--- a/24_Chemist/javascript/chemist.html
+++ b/24_Chemist/javascript/chemist.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>CHEMIST</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="chemist.js"></script>
 </body>
 </html>

--- a/25_Chief/javascript/chief.html
+++ b/25_Chief/javascript/chief.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>CHIEF</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="chief.js"></script>
 </body>
 </html>

--- a/26_Chomp/javascript/chomp.html
+++ b/26_Chomp/javascript/chomp.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>CHOMP</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="chomp.js"></script>
 </body>
 </html>

--- a/27_Civil_War/javascript/civilwar.html
+++ b/27_Civil_War/javascript/civilwar.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>CIVIL WAR</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="civilwar.js"></script>
 </body>
 </html>

--- a/28_Combat/javascript/combat.html
+++ b/28_Combat/javascript/combat.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>COMBAT</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="combat.js"></script>
 </body>
 </html>

--- a/29_Craps/javascript/craps.html
+++ b/29_Craps/javascript/craps.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>CRAPS</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="craps.js"></script>
 </body>
 </html>

--- a/30_Cube/javascript/cube.html
+++ b/30_Cube/javascript/cube.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>CUBE</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="cube.js"></script>
 </body>
 </html>

--- a/31_Depth_Charge/javascript/depthcharge.html
+++ b/31_Depth_Charge/javascript/depthcharge.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>DEPTH CHARGE</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="depthcharge.js"></script>
 </body>
 </html>

--- a/32_Diamond/javascript/diamond.html
+++ b/32_Diamond/javascript/diamond.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>DIAMOND</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="diamond.js"></script>
 </body>
 </html>

--- a/33_Dice/javascript/dice.html
+++ b/33_Dice/javascript/dice.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>DICE</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="dice.js"></script>
 </body>
 </html>

--- a/34_Digits/javascript/digits.html
+++ b/34_Digits/javascript/digits.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>DIGITS</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="digits.js"></script>
 </body>
 </html>

--- a/35_Even_Wins/javascript/evenwins.html
+++ b/35_Even_Wins/javascript/evenwins.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>EVEN WINS</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="evenwins.js"></script>
 </body>
 </html>

--- a/35_Even_Wins/javascript/gameofevenwins.html
+++ b/35_Even_Wins/javascript/gameofevenwins.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>GAME OF EVEN WINS</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="gameofevenwins.js"></script>
 </body>
 </html>

--- a/36_Flip_Flop/javascript/flipflop.html
+++ b/36_Flip_Flop/javascript/flipflop.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>FLIPFLOP</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="flipflop.js"></script>
 </body>
 </html>

--- a/37_Football/javascript/football.html
+++ b/37_Football/javascript/football.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>FOOTBALL</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="football.js"></script>
 </body>
 </html>

--- a/37_Football/javascript/ftball.html
+++ b/37_Football/javascript/ftball.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>FTBALL</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="ftball.js"></script>
 </body>
 </html>

--- a/38_Fur_Trader/javascript/furtrader.html
+++ b/38_Fur_Trader/javascript/furtrader.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>FUR TRADER</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="furtrader.js"></script>
 </body>
 </html>

--- a/39_Golf/javascript/golf.html
+++ b/39_Golf/javascript/golf.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>GOLF</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="golf.js"></script>
 </body>
 </html>

--- a/40_Gomoko/javascript/gomoko.html
+++ b/40_Gomoko/javascript/gomoko.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>GOMOKO</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="gomoko.js"></script>
 </body>
 </html>

--- a/41_Guess/javascript/guess.html
+++ b/41_Guess/javascript/guess.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>GUESS</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="guess.js"></script>
 </body>
 </html>

--- a/42_Gunner/javascript/gunner.html
+++ b/42_Gunner/javascript/gunner.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>GUNNER</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="gunner.js"></script>
 </body>
 </html>

--- a/43_Hammurabi/javascript/hammurabi.html
+++ b/43_Hammurabi/javascript/hammurabi.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>HAMMURABI</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="hammurabi.js"></script>
 </body>
 </html>

--- a/44_Hangman/javascript/hangman.html
+++ b/44_Hangman/javascript/hangman.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>HANGMAN</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="hangman.js"></script>
 </body>
 </html>

--- a/45_Hello/javascript/hello.html
+++ b/45_Hello/javascript/hello.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>HELLO</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="hello.js"></script>
 </body>
 </html>

--- a/46_Hexapawn/javascript/hexapawn.html
+++ b/46_Hexapawn/javascript/hexapawn.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>HEXAPAWN</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="hexapawn.js"></script>
 </body>
 </html>

--- a/47_Hi-Lo/javascript/hi-lo.html
+++ b/47_Hi-Lo/javascript/hi-lo.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>HI-LO</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="hi-lo.js"></script>
 </body>
 </html>

--- a/48_High_IQ/javascript/highiq.html
+++ b/48_High_IQ/javascript/highiq.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>H-I-Q</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="highiq.js"></script>
 </body>
 </html>

--- a/49_Hockey/javascript/hockey.html
+++ b/49_Hockey/javascript/hockey.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>HOCKEY</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="hockey.js"></script>
 </body>
 </html>

--- a/50_Horserace/javascript/horserace.html
+++ b/50_Horserace/javascript/horserace.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>HORSERACE</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="horserace.js"></script>
 </body>
 </html>

--- a/51_Hurkle/javascript/hurkle.html
+++ b/51_Hurkle/javascript/hurkle.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>HURKLE</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="hurkle.js"></script>
 </body>
 </html>

--- a/52_Kinema/javascript/kinema.html
+++ b/52_Kinema/javascript/kinema.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>KINEMA</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="kinema.js"></script>
 </body>
 </html>

--- a/53_King/javascript/king.html
+++ b/53_King/javascript/king.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>KING</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="king.js"></script>
 </body>
 </html>

--- a/54_Letter/javascript/letter.html
+++ b/54_Letter/javascript/letter.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>LETTER</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="letter.js"></script>
 </body>
 </html>

--- a/55_Life/javascript/life.html
+++ b/55_Life/javascript/life.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>LIFE</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="life.js"></script>
 </body>
 </html>

--- a/56_Life_for_Two/javascript/lifefortwo.html
+++ b/56_Life_for_Two/javascript/lifefortwo.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>LIFE FOR TWO</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="lifefortwo.js"></script>
 </body>
 </html>

--- a/57_Literature_Quiz/javascript/litquiz.html
+++ b/57_Literature_Quiz/javascript/litquiz.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>LITERATURE QUIZ</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="litquiz.js"></script>
 </body>
 </html>

--- a/58_Love/javascript/love.html
+++ b/58_Love/javascript/love.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>LOVE</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="love.js"></script>
 </body>
 </html>

--- a/59_Lunar_LEM_Rocket/javascript/lem.html
+++ b/59_Lunar_LEM_Rocket/javascript/lem.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>LEM</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="lem.js"></script>
 </body>
 </html>

--- a/59_Lunar_LEM_Rocket/javascript/lunar.html
+++ b/59_Lunar_LEM_Rocket/javascript/lunar.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>LUNAR</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="lunar.js"></script>
 </body>
 </html>

--- a/60_Mastermind/javascript/mastermind.html
+++ b/60_Mastermind/javascript/mastermind.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>MASTERMIND</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="mastermind.js"></script>
 </body>
 </html>

--- a/61_Math_Dice/javascript/mathdice.html
+++ b/61_Math_Dice/javascript/mathdice.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>MATH DICE</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="mathdice.js"></script>
 </body>
 </html>

--- a/62_Mugwump/javascript/mugwump.html
+++ b/62_Mugwump/javascript/mugwump.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>MUGWUMP</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="mugwump.js"></script>
 </body>
 </html>

--- a/63_Name/javascript/name.html
+++ b/63_Name/javascript/name.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>NAME</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="name.js"></script>
 </body>
 </html>

--- a/64_Nicomachus/javascript/nicomachus.html
+++ b/64_Nicomachus/javascript/nicomachus.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>NICOMACHUS</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="nicomachus.js"></script>
 </body>
 </html>

--- a/65_Nim/javascript/nim.html
+++ b/65_Nim/javascript/nim.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>NIM</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="nim.js"></script>
 </body>
 </html>

--- a/66_Number/javascript/number.html
+++ b/66_Number/javascript/number.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>NUMBER</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="number.js"></script>
 </body>
 </html>

--- a/67_One_Check/javascript/onecheck.html
+++ b/67_One_Check/javascript/onecheck.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>ONE CHECK</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="onecheck.js"></script>
 </body>
 </html>

--- a/68_Orbit/javascript/orbit.html
+++ b/68_Orbit/javascript/orbit.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>ORBIT</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="orbit.js"></script>
 </body>
 </html>

--- a/69_Pizza/javascript/pizza.html
+++ b/69_Pizza/javascript/pizza.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>PIZZA</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="pizza.js"></script>
 </body>
 </html>

--- a/70_Poetry/javascript/poetry.html
+++ b/70_Poetry/javascript/poetry.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>POETRY</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="poetry.js"></script>
 </body>
 </html>

--- a/71_Poker/javascript/poker.html
+++ b/71_Poker/javascript/poker.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>POKER</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="poker.js"></script>
 </body>
 </html>

--- a/72_Queen/javascript/queen.html
+++ b/72_Queen/javascript/queen.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>QUEEN</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="queen.js"></script>
 </body>
 </html>

--- a/73_Reverse/javascript/reverse.html
+++ b/73_Reverse/javascript/reverse.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>REVERSE</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="reverse.js"></script>
 </body>
 </html>

--- a/74_Rock_Scissors_Paper/javascript/rockscissors.html
+++ b/74_Rock_Scissors_Paper/javascript/rockscissors.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>ROCK, SCISSORS, PAPER</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="rockscissors.js"></script>
 </body>
 </html>

--- a/75_Roulette/javascript/roulette.html
+++ b/75_Roulette/javascript/roulette.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>ROULETTE</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="roulette.js"></script>
 </body>
 </html>

--- a/76_Russian_Roulette/javascript/russianroulette.html
+++ b/76_Russian_Roulette/javascript/russianroulette.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>RUSSIAN ROULETTE</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="russianroulette.js"></script>
 </body>
 </html>

--- a/77_Salvo/javascript/salvo.html
+++ b/77_Salvo/javascript/salvo.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>SALVO</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="salvo.js"></script>
 </body>
 </html>

--- a/79_Slalom/javascript/slalom.html
+++ b/79_Slalom/javascript/slalom.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>SLALOM</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="slalom.js"></script>
 </body>
 </html>

--- a/80_Slots/javascript/slots.html
+++ b/80_Slots/javascript/slots.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>SLOTS</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="slots.js"></script>
 </body>
 </html>

--- a/81_Splat/javascript/splat.html
+++ b/81_Splat/javascript/splat.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>SPLAT</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="splat.js"></script>
 </body>
 </html>

--- a/82_Stars/javascript/stars.html
+++ b/82_Stars/javascript/stars.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>STARS</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="stars.js"></script>
 </body>
 </html>

--- a/83_Stock_Market/javascript/stockmarket.html
+++ b/83_Stock_Market/javascript/stockmarket.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>STOCKMARKET</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="stockmarket.js"></script>
 </body>
 </html>

--- a/85_Synonym/javascript/synonym.html
+++ b/85_Synonym/javascript/synonym.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>SYNONYM</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="synonym.js"></script>
 </body>
 </html>

--- a/86_Target/javascript/target.html
+++ b/86_Target/javascript/target.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>TARGET</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="target.js"></script>
 </body>
 </html>

--- a/87_3-D_Plot/javascript/3dplot.html
+++ b/87_3-D_Plot/javascript/3dplot.html
@@ -1,6 +1,7 @@
 <html>
 <head>
 <title>3D PLOT</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
 <pre id="output" style="font-size: 8pt;"></pre>

--- a/88_3-D_Tic-Tac-Toe/javascript/qubit.html
+++ b/88_3-D_Tic-Tac-Toe/javascript/qubit.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>QUBIT</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="qubit.js"></script>
 </body>
 </html>

--- a/89_Tic-Tac-Toe/javascript/tictactoe1.html
+++ b/89_Tic-Tac-Toe/javascript/tictactoe1.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>TIC TAC TOE 1</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="tictactoe1.js"></script>
 </body>
 </html>

--- a/89_Tic-Tac-Toe/javascript/tictactoe2.html
+++ b/89_Tic-Tac-Toe/javascript/tictactoe2.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>TIC TAC TOE 2</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="tictactoe2.js"></script>
 </body>
 </html>

--- a/90_Tower/javascript/tower.html
+++ b/90_Tower/javascript/tower.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>TOWER</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="tower.js"></script>
 </body>
 </html>

--- a/91_Train/javascript/train.html
+++ b/91_Train/javascript/train.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>TRAIN</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="train.js"></script>
 </body>
 </html>

--- a/92_Trap/javascript/trap.html
+++ b/92_Trap/javascript/trap.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>TRAP</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="trap.js"></script>
 </body>
 </html>

--- a/93_23_Matches/javascript/23matches.html
+++ b/93_23_Matches/javascript/23matches.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>23 MATCHES</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="23matches.js"></script>
 </body>
 </html>

--- a/94_War/javascript/war.html
+++ b/94_War/javascript/war.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>WAR</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="war.js"></script>
 </body>
 </html>

--- a/95_Weekday/javascript/weekday.html
+++ b/95_Weekday/javascript/weekday.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>WEEKDAY</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="weekday.js"></script>
 </body>
 </html>

--- a/96_Word/javascript/word.html
+++ b/96_Word/javascript/word.html
@@ -1,9 +1,10 @@
 <html>
 <head>
 <title>WORD</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
 </head>
 <body>
-<pre id="output" style="font-size: 12pt;"></pre>
+<pre id="output"></pre>
 <script src="word.js"></script>
 </body>
 </html>


### PR DESCRIPTION
-  Adds one single common stylesheet to all javascript/html files.
- The files can still be opened in the browser like before, than the styles simply won't apply.
- This is meant as an addition to #631 and is part of #577 

![image](https://user-images.githubusercontent.com/600565/158055273-2ab50a3b-0602-4b10-8d3b-6bcc995fffb4.png)
