### PR TITLE
add html for 78_Sine_Wave

### DIFF
--- a/78_Sine_Wave/javascript/sinewave.html
+++ b/78_Sine_Wave/javascript/sinewave.html
@@ -1,0 +1,16 @@
+<html>
+<head>
+<title>SINE WAVE</title>
+<link rel="stylesheet" href="../../00_Utilities/javascript/style_terminal.css" />
+</head>
+<body>
+<pre id="output"></pre>
+<script>
+	/* redirect console.log messages to the output-element in the DOM */
+	window.console = {
+		log: (text) => document.getElementById("output").innerHTML += text + "<br>"
+	}
+</script>
+<script src="sinewave.js"></script>
+</body>
+</html>


### PR DESCRIPTION
add missing javascript/browser implementation for 78_Sine_Wave.

BTW this is an example for a simple javascript implementation that can run in node.js as well as in the browser. See #117