### PR TITLE
Correct typo in C# 96_Word

### DIFF
--- a/96_Word/csharp/Program.cs
+++ b/96_Word/csharp/Program.cs
@@ -40,7 +40,7 @@ namespace word
                 if ((guess.Length != 5) || (guess.Equals("?")) || (!guess.All(char.IsLetter)))
                 {
                     guess = "";
-                    Console.WriteLine("You must guess a give letter word. Start again.");
+                    Console.WriteLine("You must guess a five letter word. Start again.");
                 }
             }
 


### PR DESCRIPTION
This commit corrects an obvious typo.