### PR TITLE
Fix NaN input for Battle

### DIFF
--- a/09_Battle/javascript/battle.js
+++ b/09_Battle/javascript/battle.js
@@ -258,6 +258,11 @@ async function main()
         print("START GAME\n");
         while (1) {
             str = await input();
+            // Check if user types anything other than a number
+            if (isNaN(str)) {
+                print("INVALID INPUT. TRY ENTERING A NUMBER INSTEAD.\n")
+                continue
+            }
             x = parseInt(str);
             y = parseInt(str.substr(str.indexOf(",") + 1));
             if (x < 1 || x > 6 || y < 1 || y > 6) {


### PR DESCRIPTION
I was trying out the Javascript version of the game Battle and stumbled across an `TypeError` when I entered `YES`:
<img width="1428" alt="Screen Shot 2022-06-22 at 10 00 30" src="https://user-images.githubusercontent.com/3438337/174980437-83c12981-c087-4184-a70f-dc4187edeee3.png">

After this error, the game doesn't recover. 
I never played the game before, but it seems to be designed to only accepts numbers as input. So I added a guard to prevent this from happening.

