### PR TITLE
Alternate readme

### DIFF
--- a/00_Alternate_Languages/README.md
+++ b/00_Alternate_Languages/README.md
@@ -1,6 +1,7 @@
 #### Alternate Languages
 
-This folder contains implementations of each program in alternate languages which are _not_ one of the agreed upon 10 languages, intended to meet these three criteria:
+This folder contains implementations of each program in alternate languages which are _not_ one of the agreed upon 10 languages.
+Implementations here are NOT bound to these three criteria:
 
 1. Popular (by TIOBE index)
 2. Memory safe

--- a/00_Alternate_Languages/README.md
+++ b/00_Alternate_Languages/README.md
@@ -8,8 +8,8 @@ Implementations here are NOT bound to these three criteria:
 2. Memory safe
 3. Generally considered a 'scripting' language
 
-So for example, (here only) C or PASCAL are allowed. Please still remain faithful to original look-and-feel (console applications),
-and try to keep the code portable (unless it is not possible, and then be very explicit about this limitation in your
+So for example, (here only) C or PASCAL are allowed. Please still remain faithful to original look-and-feel (console applications).
+Try to keep your code portable (unless it is not possible, and then be very explicit about this limitation in your
 README and your folder naming).
 
 We welcome additional ports in whatever language you prefer, but these additional ports are for educational purposes only, and do not count towards the donation total at the end of the project.

--- a/00_Alternate_Languages/README.md
+++ b/00_Alternate_Languages/README.md
@@ -1,10 +1,14 @@
 #### Alternate Languages
 
 This folder contains implementations of each program in alternate languages which are _not_ one of the agreed upon 10 languages.
+
 Implementations here are NOT bound to these three criteria:
 
 1. Popular (by TIOBE index)
 2. Memory safe
 3. Generally considered a 'scripting' language
+
+So for example, (here only) C or PASCAL are allowed, but please remain faithful to original look-and-feel (console applications
+guidelines, and try to keep the code portable (unless it is not possible, and then be very explicit about it).
 
 We welcome additional ports in whatever language you prefer, but these additional ports are for educational purposes only, and do not count towards the donation total at the end of the project.

--- a/00_Alternate_Languages/README.md
+++ b/00_Alternate_Languages/README.md
@@ -8,7 +8,8 @@ Implementations here are NOT bound to these three criteria:
 2. Memory safe
 3. Generally considered a 'scripting' language
 
-So for example, (here only) C or PASCAL are allowed, but please remain faithful to original look-and-feel (console applications
-guidelines, and try to keep the code portable (unless it is not possible, and then be very explicit about it).
+So for example, (here only) C or PASCAL are allowed. Please still remain faithful to original look-and-feel (console applications),
+and try to keep the code portable (unless it is not possible, and then be very explicit about this limitation in your
+README and your folder naming).
 
 We welcome additional ports in whatever language you prefer, but these additional ports are for educational purposes only, and do not count towards the donation total at the end of the project.


### PR DESCRIPTION
When fast reading, it seemed Alternate languages were still bound to all 3 of the original 3 criteria (so for example, C would still be disallowed).

Looking again, I may have misread. So this tries to be remove ambiguity. Cheers.