### PR TITLE
add try/except to computer prompt, invalid input should not crash game

### DIFF
--- a/84_Super_Star_Trek/python/superstartrek.py
+++ b/84_Super_Star_Trek/python/superstartrek.py
@@ -902,7 +902,10 @@ class Game:
             if len(command) == 0:
                 com = 6
             else:
-                com = int(command)
+                try:
+                    com = int(command)
+                except ValueError:
+                    com = 6
             if com < 0:
                 return
 


### PR DESCRIPTION
I was surprised to find that just '?' would crash the game there.  It doesn't deal with non-numeric input.
