### PR TITLE
Fix bug in win?/3

### DIFF
--- a/01_Acey_Ducey/elixir/acey_ducey.exs
+++ b/01_Acey_Ducey/elixir/acey_ducey.exs
@@ -73,10 +73,15 @@ defmodule Game do
   end
 
   # for a stricter win condition (non-inclusive)
-  defp win?({_, first}, {_, second}, {_, third}) when third > first and third < second, do: true
+  defp win?({_, first}, {_, second}, {_, third}) do
+    [floor, ceiling] = Enum.sort([first, second])
+    (floor < third) && (third < ceiling)
+  end
   # for a looser win condition (inclusive)
-  #defp win?({_, first}, {_, second}, {_, third}) when third in first..second, do: true
-  defp win?(_, _, _), do: false
+  #defp win?({_, first}, {_, second}, {_, third}) do
+    #[_, middle, _] = Enum.sort([first, second, third])
+    #middle == third
+  #end
 
   defp format({suit, value}) do
     case value do


### PR DESCRIPTION
Unfortunately found a bug in the previous version. It makes an incorrect assumption that the first card’s value is less than that of the second card. The new version uses `Enum.sort/1` to not rely on that assumption being true.