### PR TITLE
Updating broken link to archive.org copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 We’re updating the first million selling computer book, [BASIC Computer Games](https://en.wikipedia.org/wiki/BASIC_Computer_Games), for 2022 and beyond!
 
-- [Read the original book](https://annarchive.com/files/Basic_Computer_Games_Microcomputer_Edition.pdf) (pdf)
+- [Read the original book](https://archive.org/details/basiccomputergam0000unse) (pdf)
 - [Play the original games in your browser](https://troypress.com/wp-content/uploads/user/js-basic/index.html)
 
 ### Where can we discuss it?


### PR DESCRIPTION
The old link seems to be dead.